### PR TITLE
Separated the printer methods to visit/accept based pattern

### DIFF
--- a/src/org/pegdown/PegDownProcessor.java
+++ b/src/org/pegdown/PegDownProcessor.java
@@ -89,12 +89,11 @@ public class PegDownProcessor {
             );
         }
 
-        Printer printer = new Printer(parser.references, parser.abbreviations);
+        Printer htmlVisitor = new Printer(parser.references, parser.abbreviations);
 
-        lastParsingResult.resultValue.print(printer);
-        printer.println();
+        htmlVisitor.visit(lastParsingResult.resultValue);
 
-        return printer.getString();
+        return htmlVisitor.getString();
     }
 
     // perform tabstop expansion and add two trailing newlines

--- a/src/org/pegdown/Printer.java
+++ b/src/org/pegdown/Printer.java
@@ -18,29 +18,255 @@
 
 package org.pegdown;
 
-import org.parboiled.common.StringUtils;
-import org.pegdown.ast.AbbreviationNode;
-import org.pegdown.ast.Node;
-import org.pegdown.ast.ReferenceNode;
-import org.pegdown.ast.TextNode;
-
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 
+import org.parboiled.common.StringUtils;
+import org.pegdown.ast.AbbreviationNode;
+import org.pegdown.ast.AutoLinkNode;
+import org.pegdown.ast.BlockQuoteNode;
+import org.pegdown.ast.BulletListNode;
+import org.pegdown.ast.CodeNode;
+import org.pegdown.ast.EmphNode;
+import org.pegdown.ast.ExpLinkNode;
+import org.pegdown.ast.HeaderNode;
+import org.pegdown.ast.HtmlBlockNode;
+import org.pegdown.ast.LooseListItemNode;
+import org.pegdown.ast.MailLinkNode;
+import org.pegdown.ast.Node;
+import org.pegdown.ast.OrderedListNode;
+import org.pegdown.ast.ParaNode;
+import org.pegdown.ast.QuotedNode;
+import org.pegdown.ast.RefLinkNode;
+import org.pegdown.ast.ReferenceNode;
+import org.pegdown.ast.SimpleNode;
+import org.pegdown.ast.StrongNode;
+import org.pegdown.ast.TableCellNode;
+import org.pegdown.ast.TableColumnNode;
+import org.pegdown.ast.TableNode;
+import org.pegdown.ast.TableRowNode;
+import org.pegdown.ast.TextNode;
+import org.pegdown.ast.TightListItemNode;
+import org.pegdown.ast.VerbatimNode;
+
 /**
  * Helper class encapsulating most output functionality (i.e. AST-to-String serialization).
  */
-public class Printer {
-
+@SuppressWarnings("serial")
+public class Printer implements Visitor<Node> {
     public final Map<String, ReferenceNode> references = new HashMap<String, ReferenceNode>();
     public final Map<String, String> abbreviations = new HashMap<String, String>();
-    private final StringBuilder sb = new StringBuilder();
-    private int indent; // the current output indent
+    protected final StringBuilder sb = new StringBuilder();
+    protected int indent; // the current output indent
+	
+	public final Map<Class<? extends Node>, Visitor<? extends Node>> visitors = 
+	new HashMap<Class<? extends Node>, Visitor<? extends Node>>() {
+		{
+			put(AutoLinkNode.class, new Visitor<AutoLinkNode>(){
+				public void visit(AutoLinkNode node) {
+			        print("<a href=\"")
+	                .printEncoded(node.getText())
+	                .print("\">")
+	                .printEncoded(node.getText())
+	                .print("</a>");
+				}
+			});
+			
+			put(BlockQuoteNode.class, new Visitor<BlockQuoteNode>(){
+				public void visit(BlockQuoteNode node) {
+			        printOnNL("<blockquote>")
+	                .indent(+2).printChildren(node).indent(-2)
+	                .printOnNL("</blockquote>");
+				}
+			});
+			put(BulletListNode.class, new Visitor<BulletListNode>(){
+				public void visit(BulletListNode node) {
+					printOnNL("<ul>").indent(+2).printChildren(node).indent(-2).printOnNL("</ul>");
+				}
+			});
+			put(CodeNode.class, new Visitor<CodeNode>(){
+				public void visit(CodeNode node) {
+					print("<code>").printEncoded(node.getText()).print("</code>");
+				}
+			});
+			put(EmphNode.class, new Visitor<EmphNode>(){
+				public void visit(EmphNode node) {
+					print("<em>").printChildren(node).print("</em>");
+				}
+			});
+			put(ExpLinkNode.class, new Visitor<ExpLinkNode>(){
+				public void visit(ExpLinkNode node) {
+			        if (node.getImage()) {
+			            print("<img src=\"")
+			                    .printEncoded(node.getUrl())
+			                    .print("\"  alt=\"")
+			                    .printEncoded(printToString(node))
+			                    .print("\"/>");
+			        } else {
+			            print("<a href=\"")
+			                    .printEncoded(node.getUrl())
+			                    .print('"');
+			            if (node.getTitle() != null) {
+			                print(" title=\"")
+			                        .printEncoded(node.getTitle())
+			                        .print('"');
+			            }
+			            print('>')
+			                    .printChildren(node)
+			                    .print("</a>");
+			        }
+				}
+			});
+			put(HeaderNode.class, new Visitor<HeaderNode>(){
+				public void visit(HeaderNode node) {
+			        char c = (char) ((int)'0' + node.getLevel());
+			        print("<h").print(c).print('>').printChildren(node).print("</h").print(c).print('>');
+				}
+			});
+			put(HtmlBlockNode.class, new Visitor<HtmlBlockNode>(){
+				public void visit(HtmlBlockNode node) {
+					printOnNL(node.getText());
+				}
+			});
+			put(LooseListItemNode.class, new Visitor<LooseListItemNode>(){
+				public void visit(LooseListItemNode node) {
+					printOnNL("<li>").indent(+2).printChildren(node).indent(-2).printOnNL("</li>");
+				}
+			});
+			put(MailLinkNode.class, new Visitor<MailLinkNode>(){
+				public void visit(MailLinkNode node) {
+					print("<a href=\"mailto:").printEncoded(node.getText()).print("\">").printEncoded(node.getText()).print("</a>");
+				}
+			});
+			put(Node.class, new Visitor<Node>(){
+				public void visit(Node node) {
+					printChildren(node);
+				}
+			});
+			put(OrderedListNode.class, new Visitor<OrderedListNode>(){
+				public void visit(OrderedListNode node) {
+					printOnNL("<ol>").indent(+2).printChildren(node).indent(-2).printOnNL("</ol>");
+				}
+			});
+			put(ParaNode.class, new Visitor<ParaNode>(){
+				public void visit(ParaNode node) {
+					printOnNL("<p>").printChildren(node).print("</p>");
+				}
+			});
+			put(QuotedNode.class, new Visitor<QuotedNode>(){
+				public void visit(QuotedNode node) {
+					print(node.getOpen()).printChildren(node).print(node.getClose());
+				}
+			});
+			put(RefLinkNode.class, new Visitor<RefLinkNode>(){
+				public void visit(RefLinkNode node) {
+			        String key = printToString(node.getReferenceKey() != null ? node.getReferenceKey() : node);
+			        ReferenceNode refNode = key != null ? references.get(key.toLowerCase()) : null;
+			        if (refNode == null) {
+			            // "fake" reference link
+			            print('[').printChildren(node).print(']');
+			            if (node.getSeparatorSpace() != null) {
+			                print(node.getSeparatorSpace()).print('[');
+			                if (node.getReferenceKey() != null) node.getReferenceKey().accept(Printer.this);
+			                print(']');
+			            }
+			            return;
+			        }
 
-    public Printer(List<ReferenceNode> references, List<AbbreviationNode> abbreviations) {
-        for (ReferenceNode node : references) {
+			        if (node.getImage()) {
+			            print("<img src=\"")
+			                    .printEncoded(refNode.getUrl())
+			                    .print("\"  alt=\"")
+			                    .printEncoded(printToString(node))
+			                    .print("\"/>");
+			        } else {
+			            print("<a href=\"")
+			                    .printEncoded(refNode.getUrl())
+			                    .print('"');
+			            if (refNode.getTitle() != null) {
+			                print(" title=\"")
+			                        .printEncoded(refNode.getTitle())
+			                        .print('"');
+			            }
+			            print('>')
+			                    .printChildren(node)
+			                    .print("</a>");
+			        }
+				}
+			});
+			put(SimpleNode.class, new Visitor<SimpleNode>(){
+				public void visit(SimpleNode node) {
+			        switch (node.getType()) {
+		            case SimpleNode.APOSTROPHE:
+		            case SimpleNode.ELLIPSIS:
+		            case SimpleNode.EMDASH:
+		            case SimpleNode.ENDASH:
+		            case SimpleNode.NBSP:
+		                print(node.getText());
+		                return;
+		            case SimpleNode.HRULE:
+		                printOnNL("<hr/>");
+		                return;
+		            case SimpleNode.LINEBREAK:
+		                print("<br/>").println();
+		                return;
+		        }
+
+		        throw new IllegalStateException();
+				}
+			});
+			put(StrongNode.class, new Visitor<StrongNode>(){
+				public void visit(StrongNode node) {
+					print("<strong>").printChildren(node).print("</strong>");
+				}
+			});
+			put(TableNode.class, new Visitor<TableNode>(){
+				public void visit(TableNode node) {
+			        printOnNL("<table>").indent(+2);
+
+			        boolean inHeader = false;
+			        List<Node> children = node.getChildren();
+			        for (int i = 0, childrenSize = children.size(); i < childrenSize; i++) {
+			            TableRowNode rowNode = (TableRowNode) children.get(i);
+
+			            if (i == 0) {
+			                inHeader = rowNode.isHeader();
+			                printOnNL(inHeader ? "<thead>" : "<tbody>").indent(+2);
+			            } else {
+			                if (inHeader && !rowNode.isHeader()) {
+			                    indent(-2).printOnNL("</thead>").printOnNL("<tbody>").indent(+2);
+			                    inHeader = false;
+			                }
+			            }
+
+			            print(rowNode, node.getColumns());
+			        }
+			        indent(-2).printOnNL(inHeader ? "</thead>" : "</tbody>");
+			        indent(-2).printOnNL("</table>");
+				}
+			});
+			put(TextNode.class, new Visitor<TextNode>(){
+				public void visit(TextNode node) {
+					print(node.getText());
+				}
+			});
+			put(TightListItemNode.class, new Visitor<TightListItemNode>(){
+				public void visit(TightListItemNode node) {
+					printOnNL("<li>").printChildren(node).print("</li>");
+				}
+			});
+			put(VerbatimNode.class, new Visitor<VerbatimNode>(){
+				public void visit(VerbatimNode node) {
+					printOnNL("<pre><code>").printEncoded(node.getText()).print("</code></pre>");
+				}
+			});
+		}
+	};
+
+	public Printer(List<ReferenceNode> references, List<AbbreviationNode> abbreviations) {
+    	for (ReferenceNode node : references) {
             this.references.put(printToString(node).toLowerCase(), node);
         }
 
@@ -50,6 +276,63 @@ public class Printer {
             abbrevs.put(printToString(node), encode(printToString(node.getExpansion())));
         }
         this.abbreviations.putAll(abbrevs);
+	}
+
+	@SuppressWarnings({ "rawtypes", "unchecked" })
+	@Override
+	public void visit(Node node) {
+		Visitor visitor = visitors.get(node.getClass());
+		if(visitor != null) {
+			visitor.visit(node);
+		}
+	}
+    
+	/*
+	 * Print functions for table structure
+	 */
+    void print(TableRowNode row, List<TableColumnNode> columns) {
+        printOnNL("<tr>").indent(+2);
+        List<Node> children = row.getChildren();
+
+        int col = 0;
+        for (int i = 0, childrenSize = children.size(); i < childrenSize; i++) {
+            TableCellNode cell = (TableCellNode) children.get(i);
+            print(cell, col < columns.size() ? columns.get(col) : null, row.isHeader());
+            col += cell.getColSpan();
+        }
+
+        indent(-2).printOnNL("</tr>");
+    }
+
+
+    public void print(TableCellNode cell, TableColumnNode column, boolean header) {
+        printOnNL(header ? "<th" : "<td");
+        if (column != null) printAlignment(column);
+        int colSpan = cell.getColSpan();
+        if (colSpan > 1) print(" colspan=\"").print(Integer.toString(colSpan)).print('"');
+        print('>');
+
+        indent(+2).printChildren(cell).indent(-2);
+
+        print(header ? "</th>" : "</td>");
+    }
+    
+    
+    public void printAlignment(TableColumnNode column) {
+        switch (column.getAlignment()) {
+            case 0x00:
+                return;
+            case 0x01:
+                print(" align=\"left\"");
+                return;
+            case 0x02:
+                print(" align=\"right\"");
+                return;
+            case 0x03:
+                print(" align=\"center\"");
+                return;
+        }
+        throw new IllegalStateException();
     }
 
     public Printer indent(int delta) {
@@ -159,7 +442,7 @@ public class Printer {
                     printWithAbbreviations(sb.toString());
                     sb.setLength(0);
                 }
-                child.print(this);
+                child.accept(this);
             }
         }
         if (sb.length() > 0) printWithAbbreviations(sb.toString());
@@ -174,7 +457,7 @@ public class Printer {
         sb.setLength(len);
         return text.replace("\n ", " ").replace(" \n", " ").replace('\n', ' ');
     }
-
+    
     public static String encode(String string) {
         if (string == null) return null;
         for (int i = 0; i < string.length(); i++) {

--- a/src/org/pegdown/Visitor.java
+++ b/src/org/pegdown/Visitor.java
@@ -1,0 +1,9 @@
+package org.pegdown;
+
+import org.pegdown.ast.Node;
+
+public interface Visitor<T extends Node> {
+
+    public void visit(T node);
+    
+}

--- a/src/org/pegdown/ast/AbbreviationNode.java
+++ b/src/org/pegdown/ast/AbbreviationNode.java
@@ -18,7 +18,6 @@
 
 package org.pegdown.ast;
 
-import org.pegdown.Printer;
 
 public class AbbreviationNode extends Node {
 
@@ -35,11 +34,6 @@ public class AbbreviationNode extends Node {
     public boolean setExpansion(Node expansion) {
         this.expansion = expansion;
         return true;
-    }
-
-    @Override
-    public void print(Printer printer) {
-        // abreviations are not printed
     }
 
 }

--- a/src/org/pegdown/ast/AutoLinkNode.java
+++ b/src/org/pegdown/ast/AutoLinkNode.java
@@ -18,22 +18,10 @@
 
 package org.pegdown.ast;
 
-import org.pegdown.Printer;
 
 public class AutoLinkNode extends Node {
 
     public AutoLinkNode(String text) {
         super(text);
     }
-
-    @Override
-    public void print(Printer printer) {
-        printer
-                .print("<a href=\"")
-                .printEncoded(getText())
-                .print("\">")
-                .printEncoded(getText())
-                .print("</a>");
-    }
-
 }

--- a/src/org/pegdown/ast/BlockQuoteNode.java
+++ b/src/org/pegdown/ast/BlockQuoteNode.java
@@ -18,18 +18,10 @@
 
 package org.pegdown.ast;
 
-import org.pegdown.Printer;
 
 public class BlockQuoteNode extends Node {
 
     public BlockQuoteNode(Node firstChild) {
         super(firstChild);
-    }
-    @Override
-    public void print(Printer printer) {
-        printer
-                .printOnNL("<blockquote>")
-                .indent(+2).printChildren(this).indent(-2)
-                .printOnNL("</blockquote>");
     }
 }

--- a/src/org/pegdown/ast/BulletListNode.java
+++ b/src/org/pegdown/ast/BulletListNode.java
@@ -18,16 +18,10 @@
 
 package org.pegdown.ast;
 
-import org.pegdown.Printer;
 
 public class BulletListNode extends Node {
 
     public BulletListNode(Node firstChild) {
         super(firstChild);
     }
-    @Override
-    public void print(Printer printer) {
-        printer.printOnNL("<ul>").indent(+2).printChildren(this).indent(-2).printOnNL("</ul>");
-    }
-
 }

--- a/src/org/pegdown/ast/CodeNode.java
+++ b/src/org/pegdown/ast/CodeNode.java
@@ -18,17 +18,10 @@
 
 package org.pegdown.ast;
 
-import org.pegdown.Printer;
 
 public class CodeNode extends Node {
 
     public CodeNode(String text) {
         super(text);
     }
-
-    @Override
-    public void print(Printer printer) {
-        printer.print("<code>").printEncoded(getText()).print("</code>");
-    }
-
 }

--- a/src/org/pegdown/ast/EmphNode.java
+++ b/src/org/pegdown/ast/EmphNode.java
@@ -18,17 +18,10 @@
 
 package org.pegdown.ast;
 
-import org.pegdown.Printer;
 
 public class EmphNode extends Node {
 
     public EmphNode(Node firstChild) {
         super(firstChild);
     }
-
-    @Override
-    public void print(Printer printer) {
-        printer.print("<em>").printChildren(this).print("</em>");
-    }
-
 }

--- a/src/org/pegdown/ast/ExpLinkNode.java
+++ b/src/org/pegdown/ast/ExpLinkNode.java
@@ -18,7 +18,6 @@
 
 package org.pegdown.ast;
 
-import org.pegdown.Printer;
 
 public class ExpLinkNode extends Node {
 
@@ -45,30 +44,15 @@ public class ExpLinkNode extends Node {
         return this;
     }
 
-    @Override
-    public void print(Printer printer) {
-        if (image) {
-            printer
-                    .print("<img src=\"")
-                    .printEncoded(url)
-                    .print("\"  alt=\"")
-                    .printEncoded(printer.printToString(this))
-                    .print("\"/>");
-        } else {
-            printer
-                    .print("<a href=\"")
-                    .printEncoded(url)
-                    .print('"');
-            if (title != null) {
-                printer
-                        .print(" title=\"")
-                        .printEncoded(title)
-                        .print('"');
-            }
-            printer
-                    .print('>')
-                    .printChildren(this)
-                    .print("</a>");
-        }
-    }
+    public String getUrl() {
+		return url;
+	}
+
+	public String getTitle() {
+		return title;
+	}
+
+	public boolean getImage() {
+		return image;
+	}
 }

--- a/src/org/pegdown/ast/HeaderNode.java
+++ b/src/org/pegdown/ast/HeaderNode.java
@@ -19,7 +19,6 @@
 package org.pegdown.ast;
 
 import org.parboiled.google.base.Preconditions;
-import org.pegdown.Printer;
 
 public class HeaderNode extends Node {
 
@@ -35,10 +34,7 @@ public class HeaderNode extends Node {
         this.level = level;
     }
 
-    @Override
-    public void print(Printer printer) {
-        char c = (char) ((int)'0' + level);
-        printer.print("<h").print(c).print('>').printChildren(this).print("</h").print(c).print('>');
-    }
-
+    public int getLevel() {
+		return level;
+	}
 }

--- a/src/org/pegdown/ast/HtmlBlockNode.java
+++ b/src/org/pegdown/ast/HtmlBlockNode.java
@@ -18,16 +18,10 @@
 
 package org.pegdown.ast;
 
-import org.pegdown.Printer;
 
 public class HtmlBlockNode extends Node {
 
     public HtmlBlockNode(String text) {
         super(text);
-    }
-
-    @Override
-    public void print(Printer printer) {
-        printer.printOnNL(getText());
     }
 }

--- a/src/org/pegdown/ast/LooseListItemNode.java
+++ b/src/org/pegdown/ast/LooseListItemNode.java
@@ -18,7 +18,6 @@
 
 package org.pegdown.ast;
 
-import org.pegdown.Printer;
 
 public class LooseListItemNode extends Node {
 
@@ -27,10 +26,5 @@ public class LooseListItemNode extends Node {
 
     public LooseListItemNode(Node firstChild) {
         super(firstChild);
-    }
-    
-    @Override
-    public void print(Printer printer) {
-        printer.printOnNL("<li>").indent(+2).printChildren(this).indent(-2).printOnNL("</li>");
     }
 }

--- a/src/org/pegdown/ast/MailLinkNode.java
+++ b/src/org/pegdown/ast/MailLinkNode.java
@@ -18,16 +18,10 @@
 
 package org.pegdown.ast;
 
-import org.pegdown.Printer;
 
 public class MailLinkNode extends Node {
 
     public MailLinkNode(String text) {
         super(text);
-    }
-
-    @Override
-    public void print(Printer printer) {
-        printer.print("<a href=\"mailto:").printEncoded(getText()).print("\">").printEncoded(getText()).print("</a>");
     }
 }

--- a/src/org/pegdown/ast/Node.java
+++ b/src/org/pegdown/ast/Node.java
@@ -21,9 +21,7 @@ package org.pegdown.ast;
 import org.parboiled.common.StringUtils;
 import org.parboiled.trees.MutableTreeNodeImpl;
 import org.parboiled.trees.TreeUtils;
-import org.pegdown.Printer;
-
-import java.util.List;
+import org.pegdown.Visitor;
 
 /**
  * Base class of all AST nodes classes. Provides the basic infrastructure and can be used directly as a simple
@@ -55,8 +53,8 @@ public class Node extends MutableTreeNodeImpl<Node> {
         return true;
     }
 
-    public void print(Printer printer) {
-        printer.printChildren(this);
+    public void accept(Visitor<Node> visitor) {
+        visitor.visit(this);
     }
 
     @Override

--- a/src/org/pegdown/ast/OrderedListNode.java
+++ b/src/org/pegdown/ast/OrderedListNode.java
@@ -18,16 +18,10 @@
 
 package org.pegdown.ast;
 
-import org.pegdown.Printer;
 
 public class OrderedListNode extends Node {
 
     public OrderedListNode(Node firstChild) {
         super(firstChild);
-    }
-    
-    @Override
-    public void print(Printer printer) {
-        printer.printOnNL("<ol>").indent(+2).printChildren(this).indent(-2).printOnNL("</ol>");
     }
 }

--- a/src/org/pegdown/ast/ParaNode.java
+++ b/src/org/pegdown/ast/ParaNode.java
@@ -18,18 +18,10 @@
 
 package org.pegdown.ast;
 
-import org.parboiled.google.base.Preconditions;
-import org.pegdown.Printer;
-
-import java.util.List;
 
 public class ParaNode extends Node {
 
     public ParaNode(Node firstChild) {
         super(firstChild);
-    }
-    @Override
-    public void print(Printer printer) {
-        printer.printOnNL("<p>").printChildren(this).print("</p>");
     }
 }

--- a/src/org/pegdown/ast/QuotedNode.java
+++ b/src/org/pegdown/ast/QuotedNode.java
@@ -18,7 +18,6 @@
 
 package org.pegdown.ast;
 
-import org.pegdown.Printer;
 
 public class QuotedNode extends Node {
 
@@ -30,9 +29,11 @@ public class QuotedNode extends Node {
         this.close = close;
     }
 
-    @Override
-    public void print(Printer printer) {
-        printer.print(open).printChildren(this).print(close);
-    }
+    public String getOpen() {
+		return open;
+	}
 
+	public String getClose() {
+		return close;
+	}
 }

--- a/src/org/pegdown/ast/RefLinkNode.java
+++ b/src/org/pegdown/ast/RefLinkNode.java
@@ -18,8 +18,6 @@
 
 package org.pegdown.ast;
 
-import org.parboiled.common.StringUtils;
-import org.pegdown.Printer;
 
 public class RefLinkNode extends Node {
 
@@ -31,7 +29,19 @@ public class RefLinkNode extends Node {
         super(firstChild);
     }
 
-    public boolean setSeparatorSpace(String separatorSpace) {
+    public boolean getImage() {
+		return image;
+	}
+
+	public String getSeparatorSpace() {
+		return separatorSpace;
+	}
+
+	public Node getReferenceKey() {
+		return referenceKey;
+	}
+
+	public boolean setSeparatorSpace(String separatorSpace) {
         this.separatorSpace = separatorSpace;
         return true;
     }
@@ -44,45 +54,5 @@ public class RefLinkNode extends Node {
     public RefLinkNode asImage() {
         image = true;
         return this;
-    }
-
-    @Override
-    public void print(Printer printer) {
-        String key = printer.printToString(referenceKey != null ? referenceKey : this);
-        ReferenceNode refNode = key != null ? printer.references.get(key.toLowerCase()) : null;
-        if (refNode == null) {
-            // "fake" reference link
-            printer.print('[').printChildren(this).print(']');
-            if (separatorSpace != null) {
-                printer.print(separatorSpace).print('[');
-                if (referenceKey != null) referenceKey.print(printer);
-                printer.print(']');
-            }
-            return;
-        }
-
-        if (image) {
-            printer
-                    .print("<img src=\"")
-                    .printEncoded(refNode.getUrl())
-                    .print("\"  alt=\"")
-                    .printEncoded(printer.printToString(this))
-                    .print("\"/>");
-        } else {
-            printer
-                    .print("<a href=\"")
-                    .printEncoded(refNode.getUrl())
-                    .print('"');
-            if (refNode.getTitle() != null) {
-                printer
-                        .print(" title=\"")
-                        .printEncoded(refNode.getTitle())
-                        .print('"');
-            }
-            printer
-                    .print('>')
-                    .printChildren(this)
-                    .print("</a>");
-        }
     }
 }

--- a/src/org/pegdown/ast/ReferenceNode.java
+++ b/src/org/pegdown/ast/ReferenceNode.java
@@ -18,7 +18,6 @@
 
 package org.pegdown.ast;
 
-import org.pegdown.Printer;
 
 public class ReferenceNode extends Node {
 
@@ -43,10 +42,4 @@ public class ReferenceNode extends Node {
         this.title = title;
         return true;
     }
-
-    @Override
-    public void print(Printer printer) {
-        // references are not printed
-    }
-
 }

--- a/src/org/pegdown/ast/SimpleNode.java
+++ b/src/org/pegdown/ast/SimpleNode.java
@@ -18,7 +18,6 @@
 
 package org.pegdown.ast;
 
-import org.pegdown.Printer;
 
 public class SimpleNode extends Node implements SimpleNodeTypes {
 
@@ -28,26 +27,9 @@ public class SimpleNode extends Node implements SimpleNodeTypes {
         this.type = type;
     }
 
-    @Override
-    public void print(Printer p) {
-        switch (type) {
-            case APOSTROPHE:
-            case ELLIPSIS:
-            case EMDASH:
-            case ENDASH:
-            case NBSP:
-                p.print(getText());
-                return;
-            case HRULE:
-                p.printOnNL("<hr/>");
-                return;
-            case LINEBREAK:
-                p.print("<br/>").println();
-                return;
-        }
-
-        throw new IllegalStateException();
-    }
+    public int getType() {
+		return type;
+	}
 
     @Override
     public String getText() {

--- a/src/org/pegdown/ast/StrongNode.java
+++ b/src/org/pegdown/ast/StrongNode.java
@@ -18,17 +18,10 @@
 
 package org.pegdown.ast;
 
-import org.pegdown.Printer;
 
 public class StrongNode extends Node {
 
     public StrongNode(Node firstChild) {
         super(firstChild);
     }
-
-    @Override
-    public void print(Printer printer) {
-        printer.print("<strong>").printChildren(this).print("</strong>");
-    }
-
 }

--- a/src/org/pegdown/ast/TableCellNode.java
+++ b/src/org/pegdown/ast/TableCellNode.java
@@ -18,7 +18,6 @@
 
 package org.pegdown.ast;
 
-import org.pegdown.Printer;
 
 public class TableCellNode extends Node {
     private int colSpan;
@@ -29,16 +28,5 @@ public class TableCellNode extends Node {
     public boolean setColSpan(int colSpan) {
         this.colSpan = colSpan;
         return true;
-    }
-
-    public void print(Printer printer, TableColumnNode column, boolean header) {
-        printer.printOnNL(header ? "<th" : "<td");
-        if (column != null) column.printAlignment(printer);
-        if (colSpan > 1) printer.print(" colspan=\"").print(Integer.toString(colSpan)).print('"');
-        printer.print('>');
-
-        printer.indent(+2).printChildren(this).indent(-2);
-
-        printer.print(header ? "</th>" : "</td>");
     }
 }

--- a/src/org/pegdown/ast/TableColumnNode.java
+++ b/src/org/pegdown/ast/TableColumnNode.java
@@ -18,7 +18,6 @@
 
 package org.pegdown.ast;
 
-import org.pegdown.Printer;
 
 public class TableColumnNode extends Node {
 
@@ -33,22 +32,8 @@ public class TableColumnNode extends Node {
         alignment |= 0x02;
         return true;
     }
-    
-    public void printAlignment(Printer printer) {
-        switch (alignment) {
-            case 0x00:
-                return;
-            case 0x01:
-                printer.print(" align=\"left\"");
-                return;
-            case 0x02:
-                printer.print(" align=\"right\"");
-                return;
-            case 0x03:
-                printer.print(" align=\"center\"");
-                return;
-        }
-        throw new IllegalStateException();
-    }
 
+	public int getAlignment() {
+		return alignment;
+	}
 }

--- a/src/org/pegdown/ast/TableNode.java
+++ b/src/org/pegdown/ast/TableNode.java
@@ -18,14 +18,12 @@
 
 package org.pegdown.ast;
 
-import org.pegdown.Printer;
-
 import java.util.ArrayList;
 import java.util.List;
 
 public class TableNode extends Node {
 
-    private List<TableColumnNode> columns;
+	private List<TableColumnNode> columns;
 
     public boolean addColumn(TableColumnNode columnNode) {
         if (columns == null) {
@@ -37,30 +35,8 @@ public class TableNode extends Node {
     public boolean hasTwoOrMoreDividers() {
         return columns != null && columns.size() > 1;
     }
-
-    @Override
-    public void print(Printer printer) {
-        printer.printOnNL("<table>").indent(+2);
-
-        boolean inHeader = false;
-        List<Node> children = getChildren();
-        for (int i = 0, childrenSize = children.size(); i < childrenSize; i++) {
-            TableRowNode rowNode = (TableRowNode) children.get(i);
-
-            if (i == 0) {
-                inHeader = rowNode.isHeader();
-                printer.printOnNL(inHeader ? "<thead>" : "<tbody>").indent(+2);
-            } else {
-                if (inHeader && !rowNode.isHeader()) {
-                    printer.indent(-2).printOnNL("</thead>").printOnNL("<tbody>").indent(+2);
-                    inHeader = false;
-                }
-            }
-
-            rowNode.print(printer, columns);
-        }
-        printer.indent(-2).printOnNL(inHeader ? "</thead>" : "</tbody>");
-        printer.indent(-2).printOnNL("</table>");
-    }
-
+    
+    public List<TableColumnNode> getColumns() {
+		return columns;
+	}
 }

--- a/src/org/pegdown/ast/TableRowNode.java
+++ b/src/org/pegdown/ast/TableRowNode.java
@@ -18,9 +18,6 @@
 
 package org.pegdown.ast;
 
-import org.pegdown.Printer;
-
-import java.util.List;
 
 public class TableRowNode extends Node {
 
@@ -34,19 +31,4 @@ public class TableRowNode extends Node {
         header = true;
         return this;
     }
-
-    public void print(Printer printer, List<TableColumnNode> columns) {
-        printer.printOnNL("<tr>").indent(+2);
-        List<Node> children = getChildren();
-
-        int col = 0;
-        for (int i = 0, childrenSize = children.size(); i < childrenSize; i++) {
-            TableCellNode cell = (TableCellNode) children.get(i);
-            cell.print(printer, col < columns.size() ? columns.get(col) : null, header);
-            col += cell.getColSpan();
-        }
-
-        printer.indent(-2).printOnNL("</tr>");
-    }
-
 }

--- a/src/org/pegdown/ast/TextNode.java
+++ b/src/org/pegdown/ast/TextNode.java
@@ -18,17 +18,10 @@
 
 package org.pegdown.ast;
 
-import org.pegdown.Printer;
 
 public class TextNode extends Node {
 
     public TextNode(String text) {
         super(text);
     }
-
-    @Override
-    public void print(Printer printer) {
-        printer.print(getText());
-    }
-
 }

--- a/src/org/pegdown/ast/TightListItemNode.java
+++ b/src/org/pegdown/ast/TightListItemNode.java
@@ -18,7 +18,6 @@
 
 package org.pegdown.ast;
 
-import org.pegdown.Printer;
 
 public class TightListItemNode extends Node {
 
@@ -28,10 +27,4 @@ public class TightListItemNode extends Node {
     public TightListItemNode(Node firstChild) {
         super(firstChild);
     }
-
-    @Override
-    public void print(Printer printer) {
-        printer.printOnNL("<li>").printChildren(this).print("</li>");
-    }
-
 }

--- a/src/org/pegdown/ast/VerbatimNode.java
+++ b/src/org/pegdown/ast/VerbatimNode.java
@@ -18,16 +18,10 @@
 
 package org.pegdown.ast;
 
-import org.pegdown.Printer;
 
 public class VerbatimNode extends Node {
 
     public VerbatimNode(String text) {
         super(text);
-    }
-
-    @Override
-    public void print(Printer printer) {
-        printer.printOnNL("<pre><code>").printEncoded(getText()).print("</code></pre>");
     }
 }


### PR DESCRIPTION
Changes to 0.8.5.4 version of Pegdown module  to support printers outside the node structures
- Parser.java : Wildcard to specific imports and removed unneeded warnings
- PegDownProcessor.java : Converted to htmlVisitor.visit invocation as a separate printer
- Visitor.java (new file) : Simple visitor interface that can be passed to Node.accept
- Printer.java : Is a delegate visitor with a aregistry of specific Node type to Visitor mapping
- org.pegdown.ast.\* classes : replaced 'print' with 'accept(visitor)' in Node.java for separate printers 
- Ran the test cases succesfully using 'ant test'
