### PR TITLE
Fix broken Java 1.5 compatibility

### DIFF
--- a/src/main/java/org/pegdown/ToHtmlSerializer.java
+++ b/src/main/java/org/pegdown/ToHtmlSerializer.java
@@ -125,7 +125,7 @@ public class ToHtmlSerializer implements Visitor, Printer.Encoder {
 
     public void visit(HtmlBlockNode node) {
         String text = node.getText();
-        if (!text.isEmpty()) printer.println();
+        if (text.length() > 0) printer.println();
         printer.print(text);
     }
 


### PR DESCRIPTION
Hi,
commit 730b0540c9037ca196f9d3be02f9a8b342b92103 broke Java 1.5 compatibility, because it uses `String.isEmpty()`, which was introduced in Java 1.6.

Cheers,
Julien
