### PR TITLE
Recognize attribute names with underscores

### DIFF
--- a/src/main/java/org/pegdown/Parser.java
+++ b/src/main/java/org/pegdown/Parser.java
@@ -893,7 +893,7 @@ public class Parser extends BaseParser<Object> implements Extensions {
 
     public Rule HtmlAttribute() {
         return Sequence(
-                OneOrMore(FirstOf(Alphanumeric(), '-')),
+                OneOrMore(FirstOf(Alphanumeric(), '-', '_')),
                 Spn1(),
                 Optional('=', Spn1(), FirstOf(Quoted(), OneOrMore(TestNot('>'), Nonspacechar()))),
                 Spn1()

--- a/src/test/java/org/pegdown/CustomPegDownTest.java
+++ b/src/test/java/org/pegdown/CustomPegDownTest.java
@@ -49,6 +49,7 @@ public class CustomPegDownTest extends AbstractTest {
     @Test
     public void customPegDownTests() {
         test("pegdown/Abbreviations");
+        test("pegdown/AttributeWithUnderScore");
         test("pegdown/Autolinks");
         test("pegdown/Bug_in_0.8.5.1");
         test("pegdown/Bug_in_0.8.5.4");

--- a/src/test/resources/pegdown/AttributeWithUnderscore.html
+++ b/src/test/resources/pegdown/AttributeWithUnderscore.html
@@ -1,0 +1,7 @@
+<p>Some text</p>
+
+<div attr_with_underscore="the value">
+then a div
+</div>
+
+<p>Then some other text</p>

--- a/src/test/resources/pegdown/AttributeWithUnderscore.md
+++ b/src/test/resources/pegdown/AttributeWithUnderscore.md
@@ -1,0 +1,7 @@
+Some text
+
+<div attr_with_underscore="the value">
+then a div
+</div>
+
+Then some other text


### PR DESCRIPTION
This is a fix for issue #32.
