### PR TITLE
Plugin SPI for pegdown

### DIFF
--- a/src/main/java/org/pegdown/Parser.java
+++ b/src/main/java/org/pegdown/Parser.java
@@ -32,6 +32,7 @@ import org.parboiled.support.StringVar;
 import org.parboiled.support.Var;
 import org.pegdown.ast.*;
 import org.pegdown.ast.SimpleNode.Type;
+import org.pegdown.plugins.PegdownPlugins;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -63,14 +64,20 @@ public class Parser extends BaseParser<Object> implements Extensions {
     protected final int options;
     protected final long maxParsingTimeInMillis;
     protected final ParseRunnerProvider parseRunnerProvider;
+    protected final PegdownPlugins plugins;
     final List<AbbreviationNode> abbreviations = new ArrayList<AbbreviationNode>();
     final List<ReferenceNode> references = new ArrayList<ReferenceNode>();
     long parsingStartTimeStamp = 0L;
 
-    public Parser(Integer options, Long maxParsingTimeInMillis, ParseRunnerProvider parseRunnerProvider) {
+    public Parser(Integer options, Long maxParsingTimeInMillis, ParseRunnerProvider parseRunnerProvider, PegdownPlugins plugins) {
         this.options = options;
         this.maxParsingTimeInMillis = maxParsingTimeInMillis;
         this.parseRunnerProvider = parseRunnerProvider;
+        this.plugins = plugins;
+    }
+
+    public Parser(Integer options, Long maxParsingTimeInMillis, ParseRunnerProvider parseRunnerProvider) {
+        this(options, maxParsingTimeInMillis, parseRunnerProvider, PegdownPlugins.NONE);
     }
 
     public RootNode parse(char[] source) {
@@ -98,6 +105,7 @@ public class Parser extends BaseParser<Object> implements Extensions {
         return Sequence(
                 ZeroOrMore(BlankLine()),
                 FirstOf(new ArrayBuilder<Rule>()
+                        .add(plugins.getBlockPluginRules())
                         .add(BlockQuote(), Verbatim())
                         .addNonNulls(ext(ABBREVIATIONS) ? Abbreviation() : null)
                         .add(Reference(), HorizontalRule(), Heading(), OrderedList(), BulletList(), HtmlBlock())
@@ -569,6 +577,7 @@ public class Parser extends BaseParser<Object> implements Extensions {
 
     public Rule NonLinkInline() {
         return FirstOf(new ArrayBuilder<Rule>()
+                .add(plugins.getInlinePluginRules())
                 .add(Str(), Endline(), UlOrStarLine(), Space(), StrongOrEmph(), Image(), Code(), InlineHtml(),
                         Entity(), EscapedChar())
                 .addNonNulls(ext(QUOTES) ? new Rule[]{SingleQuoted(), DoubleQuoted(), DoubleAngleQuoted()} : null)

--- a/src/main/java/org/pegdown/plugins/BlockPluginParser.java
+++ b/src/main/java/org/pegdown/plugins/BlockPluginParser.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2010-2011 Mathias Doenitz
+ *
+ * Based on peg-markdown (C) 2008-2010 John MacFarlane
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.pegdown.plugins;
+
+import org.parboiled.Rule;
+
+/**
+ * A parser that provides block parser rules for pegdown.  A pegdown plugin should implement this, along with
+ * {@link org.parboiled.BaseParser} or {@link org.pegdown.Parser} if it wants to use the pegdown utilities.
+ *
+ * This interface is intended for use with {@link PegdownPlugins.Builder#withPlugin(Class, Object...)}, in order for
+ * Java plugins to easily be registered with a parser.
+ */
+public interface BlockPluginParser {
+    Rule[] blockPluginRules();
+}

--- a/src/main/java/org/pegdown/plugins/InlinePluginParser.java
+++ b/src/main/java/org/pegdown/plugins/InlinePluginParser.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2010-2011 Mathias Doenitz
+ *
+ * Based on peg-markdown (C) 2008-2010 John MacFarlane
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.pegdown.plugins;
+
+import org.parboiled.Rule;
+
+/**
+ * A parser that provides inline parser rules for pegdown.  A pegdown plugin should implement this, along with
+ * {@link org.parboiled.BaseParser} or {@link org.pegdown.Parser} if it wants to use the pegdown utilities.
+ *
+ * This interface is intended for use with {@link PegdownPlugins.Builder#withPlugin(Class, Object...)}, in order for
+ * Java plugins to easily be registered with a parser.
+ */
+public interface InlinePluginParser {
+    Rule[] inlinePluginRules();
+}

--- a/src/main/java/org/pegdown/plugins/PegdownPlugins.java
+++ b/src/main/java/org/pegdown/plugins/PegdownPlugins.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (C) 2010-2011 Mathias Doenitz
+ *
+ * Based on peg-markdown (C) 2008-2010 John MacFarlane
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.pegdown.plugins;
+
+import org.parboiled.BaseParser;
+import org.parboiled.Parboiled;
+import org.parboiled.Rule;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Encapsulates the plugins provided to pegdown.
+ *
+ * Construct this using @{link PegdownPlugins#builder}, and then passing in either the Java plugin classes, or
+ * precompiled rules (for greater control, or if using Scala rules).
+ */
+public class PegdownPlugins {
+
+    private final Rule[] inlinePluginRules;
+    private final Rule[] blockPluginRules;
+
+    private PegdownPlugins(Rule[] inlinePluginRules, Rule[] blockPluginRules) {
+        this.inlinePluginRules = inlinePluginRules;
+        this.blockPluginRules = blockPluginRules;
+    }
+
+    public Rule[] getInlinePluginRules() {
+        return inlinePluginRules;
+    }
+
+    public Rule[] getBlockPluginRules() {
+        return blockPluginRules;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Create a builder that is a copy of the existing plugins
+     */
+    public static Builder builder(PegdownPlugins like) {
+        return builder().withInlinePluginRules(like.getInlinePluginRules()).withBlockPluginRules(like.getBlockPluginRules());
+    }
+
+    /**
+     * Convenience reference to no plugins.
+     */
+    public static PegdownPlugins NONE = builder().build();
+
+    public static class Builder {
+        private final List<Rule> inlinePluginRules = new ArrayList<Rule>();
+        private final List<Rule> blockPluginRules = new ArrayList<Rule>();
+
+        public Builder() {
+        }
+
+        public Builder withInlinePluginRules(Rule... inlinePlugins) {
+            this.inlinePluginRules.addAll(Arrays.asList(inlinePlugins));
+            return this;
+        }
+
+        public Builder withBlockPluginRules(Rule... blockPlugins) {
+            this.blockPluginRules.addAll(Arrays.asList(blockPlugins));
+            return this;
+        }
+
+        /**
+         * Add a plugin parser.  This should either implement {@link InlinePluginParser} or {@link BlockPluginParser},
+         * or both.  The parser will be enhanced by parboiled before its rules are extracted and registered here.
+         *
+         * @param pluginParser the plugin parser class.
+         * @param arguments the arguments to pass to the constructor of that class.
+         */
+        public Builder withPlugin(Class<? extends BaseParser<Object>> pluginParser, Object... arguments) {
+            // First, check that the parser implements one of the parser interfaces
+            if (!(InlinePluginParser.class.isAssignableFrom(pluginParser) ||
+                    BlockPluginParser.class.isAssignableFrom(pluginParser))) {
+                throw new IllegalArgumentException("Parser plugin must implement a parser plugin interface to be useful");
+            }
+            BaseParser<Object> parser = Parboiled.createParser(pluginParser, arguments);
+            if (parser instanceof InlinePluginParser) {
+                withInlinePluginRules(((InlinePluginParser) parser).inlinePluginRules());
+            }
+            if (parser instanceof BlockPluginParser) {
+                withBlockPluginRules(((BlockPluginParser) parser).blockPluginRules());
+            }
+            return this;
+        }
+
+        public PegdownPlugins build() {
+            return new PegdownPlugins(inlinePluginRules.toArray(new Rule[0]), blockPluginRules.toArray(new Rule[0]));
+        }
+    }
+}

--- a/src/main/java/org/pegdown/plugins/ToHtmlSerializerPlugin.java
+++ b/src/main/java/org/pegdown/plugins/ToHtmlSerializerPlugin.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2010-2011 Mathias Doenitz
+ *
+ * Based on peg-markdown (C) 2008-2010 John MacFarlane
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.pegdown.plugins;
+
+import org.pegdown.Printer;
+import org.pegdown.ast.Node;
+import org.pegdown.ast.Visitor;
+
+/**
+ * A plugin for the {@link org.pegdown.ToHtmlSerializer}
+ */
+public interface ToHtmlSerializerPlugin {
+
+    /**
+     * Visit the given node
+     *
+     * @param node The node to visit
+     * @param visitor The visitor, for delegating back to handling children, etc
+     * @param printer The printer to print output to
+     * @return true if this plugin knew how to serialize the node, false otherwise
+     */
+    boolean visit(Node node, Visitor visitor, Printer printer);
+}

--- a/src/test/java/org/pegdown/BlockPluginNode.java
+++ b/src/test/java/org/pegdown/BlockPluginNode.java
@@ -1,0 +1,16 @@
+package org.pegdown;
+
+import org.pegdown.ast.Node;
+import org.pegdown.ast.TextNode;
+import org.pegdown.ast.Visitor;
+
+public class BlockPluginNode extends TextNode {
+    public BlockPluginNode(String text) {
+        super(text);
+    }
+
+    @Override
+    public void accept(Visitor visitor) {
+        visitor.visit((Node) this);
+    }
+}

--- a/src/test/java/org/pegdown/InlinePluginNode.java
+++ b/src/test/java/org/pegdown/InlinePluginNode.java
@@ -1,0 +1,16 @@
+package org.pegdown;
+
+import org.pegdown.ast.Node;
+import org.pegdown.ast.TextNode;
+import org.pegdown.ast.Visitor;
+
+public class InlinePluginNode extends TextNode {
+    public InlinePluginNode(String text) {
+        super(text);
+    }
+
+    @Override
+    public void accept(Visitor visitor) {
+        visitor.visit((Node) this);
+    }
+}

--- a/src/test/java/org/pegdown/PluginParser.java
+++ b/src/test/java/org/pegdown/PluginParser.java
@@ -1,0 +1,49 @@
+package org.pegdown;
+
+import org.parboiled.BaseParser;
+import org.parboiled.Rule;
+import org.parboiled.support.StringBuilderVar;
+import org.pegdown.plugins.BlockPluginParser;
+import org.pegdown.plugins.InlinePluginParser;
+
+public class PluginParser extends Parser implements InlinePluginParser, BlockPluginParser {
+
+    public PluginParser() {
+        super(ALL, 1000l, DefaultParseRunnerProvider);
+    }
+
+    @Override
+    public Rule[] blockPluginRules() {
+        return new Rule[] {BlockPlugin()};
+    }
+
+    @Override
+    public Rule[] inlinePluginRules() {
+        return new Rule[] {InlinePlugin()};
+    }
+
+    public Rule InlinePlugin() {
+        StringBuilderVar text = new StringBuilderVar();
+        return NodeSequence(
+                Ch('%'),
+                OneOrMore(TestNot(Ch('%')), BaseParser.ANY, text.append(matchedChar())),
+                push(new InlinePluginNode(text.getString())),
+                Ch('%')
+        );
+    }
+
+    public Rule BlockPlugin() {
+        StringBuilderVar text = new StringBuilderVar();
+        return NodeSequence(
+                BlockPluginMarker(),
+                OneOrMore(TestNot(Newline(), BlockPluginMarker()), BaseParser.ANY, text.append(matchedChar())),
+                Newline(),
+                push(new BlockPluginNode(text.appended('\n').getString())),
+                BlockPluginMarker()
+        );
+    }
+
+    public Rule BlockPluginMarker() {
+        return Sequence(NOrMore('%', 3), Newline());
+    }
+}

--- a/src/test/resources/pegdown/Plugins.html
+++ b/src/test/resources/pegdown/Plugins.html
@@ -1,0 +1,5 @@
+<div class="blockplugin">
+A block plugin
+</div>
+
+<p><span class="inlineplugin">An inline plugin</span></p>

--- a/src/test/resources/pegdown/Plugins.md
+++ b/src/test/resources/pegdown/Plugins.md
@@ -1,0 +1,5 @@
+%%%
+A block plugin
+%%%
+
+%An inline plugin%


### PR DESCRIPTION
I'd be very interested in a plugin SPI for pegdown.

My particular use case is this.  Play framework currently uses markdown for all its documentation.  We'd like to pull all the code samples out of the documentation, and have them in Scala files that get compiled and tested, so as to ensure that our documentation always stays current.  The samples can be annotated with comments, and then referenced in the documentation, so when the documentation is compiled, it gets pulled in.  Akka does something very similar to this, but using RST.  We could move to RST, but that's a huge task, if we could stick with markdown, it would be much nicer.  This is probably not a feature that belongs in the core markdown library, but being able to plug it in would be very helpful.

I'll have a go at implementing this, but I'd like to get feedback here as to whether it would be something that would be accepted into pegdown.  I think it could be useful for more than just our use case.  It may even be a clean way forward to adding new features to the pegdown library itself.
