### PR TITLE
Adding extensible, type-specific serialization for code blocks.

### DIFF
--- a/src/main/java/org/pegdown/DefaultVerbatimSerializer.java
+++ b/src/main/java/org/pegdown/DefaultVerbatimSerializer.java
@@ -1,0 +1,30 @@
+package org.pegdown;
+
+import org.parboiled.common.StringUtils;
+import org.pegdown.ast.VerbatimNode;
+
+public class DefaultVerbatimSerializer implements VerbatimSerializer {
+    public static final DefaultVerbatimSerializer INSTANCE = new DefaultVerbatimSerializer();
+
+    @Override
+    public void serialize(final VerbatimNode node, final Printer printer) {
+        printer.println().print("<pre><code");
+        if (!StringUtils.isEmpty(node.getType())) {
+            printAttribute(printer, "class", node.getType());
+        }
+        printer.print(">");
+        String text = node.getText();
+        // print HTML breaks for all initial newlines
+        while (text.charAt(0) == '\n') {
+            printer.print("<br/>");
+            text = text.substring(1);
+        }
+        printer.printEncoded(text);
+        printer.print("</code></pre>");
+
+    }
+
+    private void printAttribute(final Printer printer, final String name, final String value) {
+        printer.print(' ').print(name).print('=').print('"').print(value).print('"');
+    }
+}

--- a/src/main/java/org/pegdown/PegDownProcessor.java
+++ b/src/main/java/org/pegdown/PegDownProcessor.java
@@ -18,6 +18,9 @@
 
 package org.pegdown;
 
+import java.util.Collections;
+import java.util.Map;
+
 import org.parboiled.Parboiled;
 import org.pegdown.ast.RootNode;
 
@@ -98,6 +101,10 @@ public class PegDownProcessor {
         return markdownToHtml(markdownSource.toCharArray(), linkRenderer);
     }
 
+	public String markdownToHtml(String markdownSource, LinkRenderer linkRenderer, Map<String, VerbatimSerializer> verbatimSerializerMap) {
+		return markdownToHtml(markdownSource.toCharArray(), linkRenderer, verbatimSerializerMap);
+	}
+
     /**
      * Converts the given markdown source to HTML.
      * If the input cannot be parsed within the configured parsing timeout the method returns null.
@@ -118,9 +125,13 @@ public class PegDownProcessor {
      * @return the HTML
      */
     public String markdownToHtml(char[] markdownSource, LinkRenderer linkRenderer) {
+	    return markdownToHtml(markdownSource, linkRenderer, Collections.<String, VerbatimSerializer>emptyMap());
+    }
+
+	public String markdownToHtml(char[] markdownSource, LinkRenderer linkRenderer, Map<String, VerbatimSerializer> verbatimSerializerMap) {
         try {
             RootNode astRoot = parseMarkdown(markdownSource);
-            return new ToHtmlSerializer(linkRenderer).toHtml(astRoot);
+            return new ToHtmlSerializer(linkRenderer, verbatimSerializerMap).toHtml(astRoot);
         } catch(ParsingTimeoutException e) {
             return null;
         }

--- a/src/main/java/org/pegdown/VerbatimSerializer.java
+++ b/src/main/java/org/pegdown/VerbatimSerializer.java
@@ -1,0 +1,9 @@
+package org.pegdown;
+
+import org.pegdown.ast.VerbatimNode;
+
+public interface VerbatimSerializer {
+    static final String DEFAULT = "DEFAULT";
+
+    void serialize(VerbatimNode node, Printer printer);
+}

--- a/src/test/resources/pegdown/GFM_Fenced_Code_Blocks_reversed_all.html
+++ b/src/test/resources/pegdown/GFM_Fenced_Code_Blocks_reversed_all.html
@@ -1,0 +1,41 @@
+<p>A fenced code block:</p>
+<pre>
+<code class="reversed-scala">
+
+}
+enoN = ]tnI[noitpO :dleif lav  
+{ )gnirtS :eman(elpmaxE ssalc
+</code>
+</pre>
+
+<p>And another one, this time with an empty line:</p>
+<pre>
+<code class="reversed-javascript">
+
+eurt // ;)(ytriDsi.durc.atad   
+;)1(retnuoc.atad   
+eslaf // ;)(ytriDsi.durc.atad   
+;)ledom ,}{(esu.cnys.ok = atad rav   
+
+;)}   
+}0 :retnuoc{ :sdleif       
+,elbat :elbaTatad       
+,erots :erotSatad       
+{(ledoM.cnys.ok = ledom rav   
+</code>
+</pre>
+
+<p>and here is another one:</p>
+<pre>
+<code class="reversed-java">
+
+}
+;)smarap ,"" ,yek ,ELDNUB(tluafeDrOegassem.eldnuBnommoC nruter    
+{ )smarap ...tcejbO ,yek gnirtS )EMAN_ELDNUB = eldnuBecruoser(yeKytreporP@(knalBrOegassem gnirtS citats cilbup
+
+}
+;)smarap ,yek ,ELDNUB(egassem.eldnuBnommoC nruter    
+{ )smarap ...tcejbO ,yek gnirtS )EMAN_ELDNUB = eldnuBecruoser(yeKytreporP@(egassem gnirtS citats cilbup
+</code>
+</pre>
+

--- a/src/test/resources/pegdown/GFM_Fenced_Code_Blocks_reversed_scala.html
+++ b/src/test/resources/pegdown/GFM_Fenced_Code_Blocks_reversed_scala.html
@@ -1,0 +1,39 @@
+<p>A fenced code block:</p>
+<pre>
+<code class="reversed-scala">
+
+}
+enoN = ]tnI[noitpO :dleif lav  
+{ )gnirtS :eman(elpmaxE ssalc
+</code>
+</pre>
+
+<p>And another one, this time with an empty line:</p>
+<pre>
+<code class="javascript">
+   var model = ko.sync.Model({
+       dataStore: store,
+       dataTable: table,
+       fields: {counter: 0}
+   });
+
+   var data = ko.sync.use({}, model);
+   data.crud.isDirty(); // false
+   data.counter(1);
+   data.crud.isDirty(); // true
+</code>
+</pre>
+
+<p>and here is another one:</p>
+<pre>
+<code class="java">
+public static String message(@PropertyKey(resourceBundle = BUNDLE_NAME) String key, Object... params) {
+    return CommonBundle.message(BUNDLE, key, params);
+}
+
+public static String messageOrBlank(@PropertyKey(resourceBundle = BUNDLE_NAME) String key, Object... params) {
+    return CommonBundle.messageOrDefault(BUNDLE, key, "", params);
+}
+</code>
+</pre>
+

--- a/src/test/scala/org/pegdown/AbstractPegDownSpec.scala
+++ b/src/test/scala/org/pegdown/AbstractPegDownSpec.scala
@@ -17,12 +17,13 @@ abstract class AbstractPegDownSpec extends Specification {
     test(testName, tidy(expectedUntidy))
   }
 
-  def test(testName: String, expectedOutput: String)(implicit processor: PegDownProcessor) {
+  def test(testName: String, expectedOutput: String, htmlSerializer: ToHtmlSerializer = null)(implicit processor: PegDownProcessor) {
     val markdown = FileUtils.readAllCharsFromResource(testName + ".md")
     require(markdown != null, "Test '" + testName + "' not found")
 
     val astRoot = processor.parseMarkdown(markdown)
-    val actualHtml = new ToHtmlSerializer(new LinkRenderer).toHtml(astRoot)
+
+    val actualHtml = Option(htmlSerializer).getOrElse(new ToHtmlSerializer(new LinkRenderer)).toHtml(astRoot)
 
     // debugging I: check the parse tree
     //assertEquals(printNodeTree(getProcessor().parser.parseToParsingResult(markdown)), "<parse tree>");


### PR DESCRIPTION
My goal was to allow special handling of specific code blocks.  I think this is a pretty succinct solution.  I toyed with the idea of using the ServiceLoader to automatically load any VerbatimSerializers registered on the classpath, but decided to go the more manual route.  Let me know if you want me to add some more automated extension loading -- or if you have any other questions or concerns about it.
