### PR TITLE
AttributeWithUnderscore test incorrectly named for case-sensitive FS

### DIFF
--- a/src/test/scala/org/pegdown/PegDownSpec.scala
+++ b/src/test/scala/org/pegdown/PegDownSpec.scala
@@ -11,7 +11,7 @@ class PegDownSpec extends AbstractPegDownSpec {
     "pass the custom pegdown tests for all extensions" in {
       def runSuite(implicit processor: PegDownProcessor) {
         test("pegdown/Abbreviations")
-        test("pegdown/AttributeWithUnderScore")
+        test("pegdown/AttributeWithUnderscore")
         test("pegdown/Autolinks")
         test("pegdown/Bug_in_0.8.5.1")
         test("pegdown/Bug_in_0.8.5.4")


### PR DESCRIPTION
Obviously the tests have never been run on a Linux machine. ;-)
