### PR TITLE
Add ToHtmlSerializerPlugins to PegDownPlugins builder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ lib_managed/
 src_managed/
 test-output/
 *.iml
+.cache
+.project
+.classpath
+.settings/

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,4 @@
 addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8.1")
+
+addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "2.1.2")
+

--- a/src/main/java/org/pegdown/PegDownProcessor.java
+++ b/src/main/java/org/pegdown/PegDownProcessor.java
@@ -19,11 +19,13 @@
 package org.pegdown;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 import org.parboiled.Parboiled;
 import org.pegdown.ast.RootNode;
 import org.pegdown.plugins.PegDownPlugins;
+import org.pegdown.plugins.ToHtmlSerializerPlugin;
 
 /**
  * A clean and lightweight Markdown-to-HTML filter based on a PEG parser implemented with parboiled.
@@ -152,13 +154,21 @@ public class PegDownProcessor {
     }
 
 	public String markdownToHtml(char[] markdownSource, LinkRenderer linkRenderer, Map<String, VerbatimSerializer> verbatimSerializerMap) {
-        try {
+        return markdownToHtml(markdownSource, linkRenderer,
+				verbatimSerializerMap, parser.plugins.getHtmlSerializerPlugins());
+    }
+
+	public String markdownToHtml(char[] markdownSource,
+			LinkRenderer linkRenderer,
+			Map<String, VerbatimSerializer> verbatimSerializerMap, 
+			List<ToHtmlSerializerPlugin> plugins) {
+		try {
             RootNode astRoot = parseMarkdown(markdownSource);
-            return new ToHtmlSerializer(linkRenderer, verbatimSerializerMap).toHtml(astRoot);
+            return new ToHtmlSerializer(linkRenderer, verbatimSerializerMap, plugins).toHtml(astRoot);
         } catch(ParsingTimeoutException e) {
             return null;
         }
-    }
+	}
 
     /**
      * Parses the given markdown source and returns the root node of the generated Abstract Syntax Tree.

--- a/src/main/java/org/pegdown/ToHtmlSerializer.java
+++ b/src/main/java/org/pegdown/ToHtmlSerializer.java
@@ -49,9 +49,7 @@ public class ToHtmlSerializer implements Visitor {
     }
 
     public ToHtmlSerializer(LinkRenderer linkRenderer, List<ToHtmlSerializerPlugin> plugins) {
-        this.linkRenderer = linkRenderer;
-        this.plugins = plugins;
-        this.verbatimSerializers = Collections.<String, VerbatimSerializer>singletonMap(VerbatimSerializer.DEFAULT, DefaultVerbatimSerializer.INSTANCE);
+    	this (linkRenderer, Collections.<String, VerbatimSerializer>emptyMap(), plugins);
     }
 
     public ToHtmlSerializer(final LinkRenderer linkRenderer, final Map<String, VerbatimSerializer> verbatimSerializers) {

--- a/src/main/java/org/pegdown/plugins/PegDownPlugins.java
+++ b/src/main/java/org/pegdown/plugins/PegDownPlugins.java
@@ -35,15 +35,17 @@ public class PegDownPlugins {
     private final Rule[] inlinePluginRules;
     private final Rule[] blockPluginRules;
     private final Character[] specialChars;
+    private final List<ToHtmlSerializerPlugin> serializerPlugins;
 
     private PegDownPlugins(Rule[] inlinePluginRules, Rule[] blockPluginRules) {
-        this(inlinePluginRules, blockPluginRules, new Character[0]);
+        this(inlinePluginRules, blockPluginRules, new Character[0], Collections.<ToHtmlSerializerPlugin>emptyList());
     }
 
-    private PegDownPlugins(Rule[] inlinePluginRules, Rule[] blockPluginRules, Character[] specialChars) {
+    private PegDownPlugins(Rule[] inlinePluginRules, Rule[] blockPluginRules, Character[] specialChars, List<ToHtmlSerializerPlugin> serializerPlugins) {
         this.inlinePluginRules = inlinePluginRules;
         this.blockPluginRules = blockPluginRules;
         this.specialChars = specialChars;
+        this.serializerPlugins = serializerPlugins;
     }
 
     public Rule[] getInlinePluginRules() {
@@ -58,6 +60,10 @@ public class PegDownPlugins {
         return specialChars;
     }
 
+    public List<ToHtmlSerializerPlugin> getHtmlSerializerPlugins() {
+    	return serializerPlugins;
+    }
+    
     public static Builder builder() {
         return new Builder();
     }
@@ -66,7 +72,8 @@ public class PegDownPlugins {
      * Create a builder that is a copy of the existing plugins
      */
     public static Builder builder(PegDownPlugins like) {
-        return builder().withInlinePluginRules(like.getInlinePluginRules()).withBlockPluginRules(like.getBlockPluginRules());
+        return builder().withInlinePluginRules(like.getInlinePluginRules()).withBlockPluginRules(like.getBlockPluginRules()).
+        		withHtmlSerializer(like.serializerPlugins.toArray(new ToHtmlSerializerPlugin[0]));
     }
 
     /**
@@ -78,6 +85,7 @@ public class PegDownPlugins {
         private final List<Rule> inlinePluginRules = new ArrayList<Rule>();
         private final List<Rule> blockPluginRules = new ArrayList<Rule>();
         private final Set<Character> specialChars = new HashSet<Character>();
+        private final List<ToHtmlSerializerPlugin> serializerPlugins = new ArrayList<ToHtmlSerializerPlugin>();
 
         public Builder() {
         }
@@ -95,6 +103,11 @@ public class PegDownPlugins {
         public Builder withSpecialChars(Character... chars) {
             Collections.addAll(this.specialChars, chars);
             return this;
+        }
+        
+        public Builder withHtmlSerializer(ToHtmlSerializerPlugin... plugins) {
+        	Collections.addAll(this.serializerPlugins, plugins);
+        	return this;
         }
 
         /**
@@ -119,10 +132,10 @@ public class PegDownPlugins {
             }
             return this;
         }
-
+        
         public PegDownPlugins build() {
             return new PegDownPlugins(inlinePluginRules.toArray(new Rule[0]), blockPluginRules.toArray(new Rule[0]),
-                    specialChars.toArray(new Character[0]));
+                    specialChars.toArray(new Character[0]), Collections.unmodifiableList(serializerPlugins));
         }
     }
 }


### PR DESCRIPTION
This change adds a way to register ToHtmlSerializerPlugin's with PegDownPlugins.  PegDownProcessor was updated to pass ToHtmlSerializerPlugin's down to the ToHtmlSerializer.

This seems to address #124