### PR TITLE
Invalid HTML when serializing images

### DIFF
--- a/src/main/java/org/pegdown/ToHtmlSerializer.java
+++ b/src/main/java/org/pegdown/ToHtmlSerializer.java
@@ -396,7 +396,7 @@ public class ToHtmlSerializer implements Visitor {
         for (LinkRenderer.Attribute attr : rendering.attributes) {
             printAttribute(attr.name, attr.value);
         }
-        printer.print("\"/>");
+        printer.print("/>");
     }
 
     protected void printLink(LinkRenderer.Rendering rendering) {


### PR DESCRIPTION
1.4.2 introduced a bug - there is an extra quote in HTML for images: `<img src="/url/" alt="image link""/>`
