### PR TITLE
Wikilink are closed by 2 closing square brackets.

### DIFF
--- a/src/main/java/org/pegdown/Parser.java
+++ b/src/main/java/org/pegdown/Parser.java
@@ -935,7 +935,7 @@ public class Parser extends BaseParser<Object> implements Extensions {
     public Rule WikiLink() {
         return Sequence(
             "[[",
-            OneOrMore(TestNot(']'), ANY), // might have to restrict from ANY
+            OneOrMore(TestNot(Sequence(']',']')), ANY), // might have to restrict from ANY
             push(new WikiLinkNode(match())),
             "]]"
         );

--- a/src/test/resources/pegdown/Wikilinks.html
+++ b/src/test/resources/pegdown/Wikilinks.html
@@ -2,7 +2,8 @@
 <p>Wikilinks are simple URIs like <a href=
 "./Autolinks.html">Autolinks</a>,<br/>
 which will be converted by pegdown.</p>
-<p>Another example with spaces: <a href="./Special-Chars.html">Special Chars</a>.</p>
+<p>Another example with spaces: <a href="./Special-Chars.html">Special Chars</a>,<br/>
+with square brackets: <a href="./%5BSquare%5DBrackets.html">[Square]Brackets</a>.</p>
 <p>The following links should work just normally:</p>
 <ul>
 <li><a href="http://example">example</a></li>

--- a/src/test/resources/pegdown/Wikilinks.md
+++ b/src/test/resources/pegdown/Wikilinks.md
@@ -3,7 +3,8 @@
 Wikilinks are simple URIs like [[Autolinks]],
 which will be converted by pegdown.
 
-Another example with spaces: [[Special Chars]].
+Another example with spaces: [[Special Chars]],
+with square brackets: [[[Square]Brackets]].
 
 The following links should work just normally:
 


### PR DESCRIPTION
In my project using pegdown I have wikilinks containing square brackets.
I've updated the wikilink rule to include everything up to 2 closing ']'. With this patch "[[MyWik]llink]]" is recognised. 
