### PR TITLE
Adds anchor links to headers.

### DIFF
--- a/src/main/java/org/pegdown/Extensions.java
+++ b/src/main/java/org/pegdown/Extensions.java
@@ -101,6 +101,11 @@ public interface Extensions {
     static final int STRIKETHROUGH = 0x200;
 
     /**
+     * Enables anchor links in headers.
+     */
+    static final int ANCHORLINKS = 0x300;
+
+    /**
      * All available extensions excluding the SUPPRESS_... options.
      */
     static final int ALL = 0x0000FFFF;

--- a/src/main/java/org/pegdown/LinkRenderer.java
+++ b/src/main/java/org/pegdown/LinkRenderer.java
@@ -22,9 +22,9 @@ public class LinkRenderer {
      * Simple model class for an HTML tag attribute.
      */
     public static class Attribute {
-        public static Attribute NO_FOLLOW = new Attribute("rel", "nofollow");
-        public String name;
-        public String value;
+        public static final Attribute NO_FOLLOW = new Attribute("rel", "nofollow");
+        public final String name;
+        public final String value;
         public Attribute(String name, String value) {
             this.name = name;
             this.value = value;
@@ -35,9 +35,9 @@ public class LinkRenderer {
      * Simple model class for holding the `href`, link text as well as other tag attributes of an HTML link.
      */
     public static class Rendering {
-        public String href;
-        public String text;
-        public List<Attribute> attributes = new ArrayList<Attribute>(2);
+        public final String href;
+        public final String text;
+        public final List<Attribute> attributes = new ArrayList<Attribute>(2);
         public Rendering(String href, String text) {
             this.href = href;
             this.text = text;
@@ -49,6 +49,11 @@ public class LinkRenderer {
             attributes.add(attr);
             return this;
         }
+    }
+
+    public Rendering render(AnchorLinkNode node) {
+        String name = node.getName();
+        return new Rendering('#' + name, node.getText()).withAttribute("name", name);
     }
 
     public Rendering render(AutoLinkNode node) {

--- a/src/main/java/org/pegdown/Parser.java
+++ b/src/main/java/org/pegdown/Parser.java
@@ -213,6 +213,7 @@ public class Parser extends BaseParser<Object> implements Extensions {
                 AtxStart(),
                 Optional(Sp()),
                 OneOrMore(AtxInline(), addAsChild()),
+                wrapInAnchor(),
                 Optional(Sp(), ZeroOrMore('#'), Sp()),
                 Newline()
         );
@@ -245,6 +246,7 @@ public class Parser extends BaseParser<Object> implements Extensions {
         return Sequence(
                 SetextInline(), push(new HeaderNode(1, popAsNode())),
                 ZeroOrMore(SetextInline(), addAsChild()),
+                wrapInAnchor(),
                 Newline(), NOrMore('=', 3), Newline()
         );
     }
@@ -253,12 +255,31 @@ public class Parser extends BaseParser<Object> implements Extensions {
         return Sequence(
                 SetextInline(), push(new HeaderNode(2, popAsNode())),
                 ZeroOrMore(SetextInline(), addAsChild()),
+                wrapInAnchor(),
                 Newline(), NOrMore('-', 3), Newline()
         );
     }
 
     public Rule SetextInline() {
         return Sequence(TestNot(Endline()), Inline());
+    }
+
+    public boolean wrapInAnchor() {
+        if (ext(ANCHORLINKS)) {
+            SuperNode node = (SuperNode) peek();
+            List<Node> children = node.getChildren();
+            if (children.size() == 1) {
+                Node child = children.get(0);
+                if (child instanceof TextNode) {
+                    AnchorLinkNode anchor = new AnchorLinkNode(((TextNode) child).getText());
+                    anchor.setStartIndex(child.getStartIndex());
+                    anchor.setEndIndex(child.getEndIndex());
+                    children.set(0, anchor);
+                }
+            }
+        }
+
+        return true;
     }
 
     //************** Definition Lists ************

--- a/src/main/java/org/pegdown/ToHtmlSerializer.java
+++ b/src/main/java/org/pegdown/ToHtmlSerializer.java
@@ -94,6 +94,10 @@ public class ToHtmlSerializer implements Visitor {
     public void visit(AbbreviationNode node) {
     }
 
+    public void visit(AnchorLinkNode node) {
+        printLink(linkRenderer.render(node));
+    }
+
     public void visit(AutoLinkNode node) {
         printLink(linkRenderer.render(node));
     }

--- a/src/main/java/org/pegdown/ast/AnchorLinkNode.java
+++ b/src/main/java/org/pegdown/ast/AnchorLinkNode.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2010-2011 Mathias Doenitz
+ *
+ * Based on peg-markdown (C) 2008-2010 John MacFarlane
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.pegdown.ast;
+
+public class AnchorLinkNode extends TextNode {
+
+    private final String name;
+
+    public AnchorLinkNode(String text) {
+        super(text);
+        this.name = generateName(text);
+    }
+
+    @Override
+    public void accept(Visitor visitor) {
+        visitor.visit(this);
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    private String generateName(String text) {
+        StringBuilder sb = new StringBuilder(text.length());
+        for (char c : text.toCharArray()) {
+            if (Character.isLetterOrDigit(c)) {
+                sb.append(Character.toLowerCase(c));
+            } else if (sb.length() > 0 && sb.charAt(sb.length() - 1) != '-') {
+                sb.append('-');
+            }
+        }
+        return sb.toString();
+    }
+
+}

--- a/src/main/java/org/pegdown/ast/Visitor.java
+++ b/src/main/java/org/pegdown/ast/Visitor.java
@@ -20,6 +20,7 @@ package org.pegdown.ast;
 
 public interface Visitor {
     void visit(AbbreviationNode node);
+    void visit(AnchorLinkNode node);
     void visit(AutoLinkNode node);
     void visit(BlockQuoteNode node);
     void visit(BulletListNode node);

--- a/src/test/resources/pegdown/AnchorLinks.html
+++ b/src/test/resources/pegdown/AnchorLinks.html
@@ -1,0 +1,5 @@
+<h1><a href="#heading-1" name="heading-1">Heading 1</a></h1>
+<p>Some text</p>
+<h1><a href="#heading-1bis" name="heading-1bis">Heading 1bis</a></h1>
+<h2><a href="#heading-2" name="heading-2">Heading 2</a></h2>
+<h3><a href="#heading-%4E09-with-cjk-%6587%5B57" name="heading-&#19977;-with-cjk-&#25991;&#23383;">Heading &#19977; with CJK &#25991;&#23383;</a></h3>

--- a/src/test/resources/pegdown/AnchorLinks.md
+++ b/src/test/resources/pegdown/AnchorLinks.md
@@ -1,0 +1,10 @@
+Heading 1
+==========
+
+Some text
+
+# Heading 1bis
+
+## Heading 2
+
+### Heading 三 with CJK 文字

--- a/src/test/resources/pegdown/AstText.ast
+++ b/src/test/resources/pegdown/AstText.ast
@@ -1,6 +1,6 @@
 RootNode [0-439]
   HeaderNode [0-11]
-    TextNode [2-10] 'Ast Test'
+    AnchorLinkNode [2-10] 'Ast Test'
   ParaNode [12-53]
     SuperNode [12-50]
       TextNode [12-17] 'This '

--- a/src/test/resources/pegdown/Autolinks.html
+++ b/src/test/resources/pegdown/Autolinks.html
@@ -1,4 +1,4 @@
-<h1>Autolinks</h1>
+<h1><a href="#autolinks" name="autolinks">Autolinks</a></h1>
 <p>Autolinks are simple URIs like <a href=
 "http://www.parboiled.org">http://www.parboiled.org</a>,<br/>
 which will be automatically &ldquo;activated&rdquo; by pegdown.</p>

--- a/src/test/resources/pegdown/Linebreaks.html
+++ b/src/test/resources/pegdown/Linebreaks.html
@@ -1,4 +1,4 @@
-<h1>Linebreaks</h1>
+<h1><a href="#linebreaks" name="linebreaks">Linebreaks</a></h1>
 <p>With the HARDWRAPS extension<br/>
 enabled all these linebreaks<br/>
 should be kept as is in the<br/>

--- a/src/test/resources/pegdown/Smartypants.html
+++ b/src/test/resources/pegdown/Smartypants.html
@@ -1,4 +1,4 @@
-<h1>Smart quotes, ellipses, dashes</h1>
+<h1><a href="#smart-quotes-ellipses-dashes" name="smart-quotes-ellipses-dashes">Smart quotes, ellipses, dashes</a></h1>
 <p>&ldquo;Hello,&rdquo; said the spider.
 &ldquo;&lsquo;Shelob&rsquo; is my name.&rdquo;</p>
 <p>&lsquo;A&rsquo;, &lsquo;B&rsquo;, and &lsquo;C&rsquo; are

--- a/src/test/resources/pegdown/Strikethrough.html
+++ b/src/test/resources/pegdown/Strikethrough.html
@@ -1,2 +1,2 @@
-<h1>Strikethrough</h1>
+<h1><a href="#strikethrough" name="strikethrough">Strikethrough</a></h1>
 <p>Strikethrough should turn <del>this</del> into <del>this</del></p>

--- a/src/test/resources/pegdown/Tables.html
+++ b/src/test/resources/pegdown/Tables.html
@@ -1,4 +1,4 @@
-<h2>Tables</h2>
+<h2><a href="#tables" name="tables">Tables</a></h2>
 <p>Simple Table:</p>
 <table>
   <thead>

--- a/src/test/resources/pegdown/Wikilinks.html
+++ b/src/test/resources/pegdown/Wikilinks.html
@@ -1,4 +1,4 @@
-<h1>Wikilinks</h1>
+<h1><a href="#wikilinks" name="wikilinks">Wikilinks</a></h1>
 <p>Wikilinks are simple URIs like <a href=
 "./Autolinks.html">Autolinks</a>,<br/>
 which will be converted by pegdown.</p>

--- a/src/test/scala/org/pegdown/EmphStrongSpec.scala
+++ b/src/test/scala/org/pegdown/EmphStrongSpec.scala
@@ -7,7 +7,7 @@ class EmphStrongSpec extends AbstractPegDownSpec {
 
   "The PegDownProcessor" should {
     "pass all tests in the EmphStrong test suite" in {
-      implicit val processor = new PegDownProcessor(ALL)
+      implicit val processor = new PegDownProcessor(ALL & ~ANCHORLINKS)
 
       test("emph-strong-test/test_1")
       test("emph-strong-test/test_2")

--- a/src/test/scala/org/pegdown/Markdown103Spec.scala
+++ b/src/test/scala/org/pegdown/Markdown103Spec.scala
@@ -40,7 +40,7 @@ class Markdown103Spec extends AbstractPegDownSpec {
 
       "with most extensions enabled" in {
         runMarkdownTestSuite {
-          new PegDownProcessor(ALL & ~SMARTYPANTS & ~HARDWRAPS)
+          new PegDownProcessor(ALL & ~SMARTYPANTS & ~HARDWRAPS & ~ANCHORLINKS)
         }
       }
     }

--- a/src/test/scala/org/pegdown/MarukuSpec.scala
+++ b/src/test/scala/org/pegdown/MarukuSpec.scala
@@ -7,7 +7,7 @@ class MarukuSpec extends AbstractPegDownSpec {
 
   "The PegDownProcessor" should {
     "pass selected parts of the Maruku test suite" in {
-      implicit val processor = new PegDownProcessor(ALL & ~HARDWRAPS)
+      implicit val processor = new PegDownProcessor(ALL & ~HARDWRAPS & ~ANCHORLINKS)
 
       test("Maruku/abbreviations")
       test("Maruku/alt")

--- a/src/test/scala/org/pegdown/PegDownSpec.scala
+++ b/src/test/scala/org/pegdown/PegDownSpec.scala
@@ -18,6 +18,7 @@ class PegDownSpec extends AbstractPegDownSpec {
       def runSuite(implicit processor: PegDownProcessor) {
         test("pegdown/Abbreviations")
         test("pegdown/AttributeWithUnderscore")
+        test("pegdown/AnchorLinks")
         test("pegdown/Autolinks")
         test("pegdown/Bug_in_0.8.5.1")
         test("pegdown/Bug_in_0.8.5.4")

--- a/src/test/scala/org/pegdown/PhpMarkdownSpec.scala
+++ b/src/test/scala/org/pegdown/PhpMarkdownSpec.scala
@@ -30,7 +30,7 @@ class PhpMarkdownSpec extends AbstractPegDownSpec {
     }
 
     "pass selected parts of the PhpMarkdownExtra test suite" in {
-      implicit val processor = new PegDownProcessor(ALL & ~SMARTYPANTS & ~HARDWRAPS)
+      implicit val processor = new PegDownProcessor(ALL & ~SMARTYPANTS & ~HARDWRAPS & ~ANCHORLINKS)
 
       test("PhpMarkdownExtra/Abbr")
       test("PhpMarkdownExtra/Definition_Lists")


### PR DESCRIPTION
Allows the generations of headings with a anchoring link, such as (when the option is enabled):

`## my heading title`

is transformed to:

`<h2><a name="my-heading-title">my heading title</a></h2>`
