### PR TITLE
Fix "Error: <aside> is not recognized!" and alike                                             

### DIFF
--- a/src/main/java/org/pegdown/Parser.java
+++ b/src/main/java/org/pegdown/Parser.java
@@ -562,9 +562,38 @@ public class Parser extends BaseParser<Object> implements Extensions {
     }
 
     protected static final String[] HTML_TAGS = new String[] {
-            "address", "blockquote", "center", "dd", "dir", "div", "dl", "dt", "fieldset", "form", "frameset", "h1",
-            "h2", "h3", "h4", "h5", "h6", "hr", "isindex", "li", "menu", "noframes", "noscript", "ol", "p", "pre",
-            "script", "style", "table", "tbody", "td", "tfoot", "th", "thead", "tr", "ul"
+        // https://developer.mozilla.org/en/docs/Web/HTML/Element
+        // Basic elements
+        "html",
+        // Document metadata
+        "base", "head", "link", "meta", "style", "title",
+        // Content sectioning
+        "address", "article", "body", "footer", "header", "h1", "h2", "h3", "h4", "h5", "h6", "hgroup", "nav", "section",
+        // Text bontent
+        "dd", "div", "dl", "dt", "figcaption", "figure", "hr", "li", "main", "ol", "p", "pre", "ul",
+        // Inline text semantics
+        "a", "abbr", "b", "bdi", "bdo", "br", "cite", "code", "data", "dfn", "em", "i", "kbd", "mark", "q", "rp", "rt",
+        "rtc", "ruby", "s", "samp", "small", "span", "strong", "sub", "sup", "time", "u", "var", "wbr",
+        // Image & multimedia
+        "area", "audio", "img", "map", "track", "video",
+        // Embedded content
+        "embed", "iframe", "object", "param", "source",
+        // Scripting
+        "canvas", "noscript", "script",
+        // Edits
+        "del", "ins",
+        // Table content
+        "caption", "col", "colgroup", "table", "tbody", "td", "tfoot", "th", "thead", "tr",
+        // Forms
+        "button", "datalist", "fieldset", "form", "input", "keygen", "label", "legend", "meter",
+        "optgroup", "option", "output", "progress", "select", "textarea",
+        // Interactive elements
+        "details", "dialog", "menu", "menuitem", "summary",
+        // Web Components
+        "content", "decorator", "element", "shadow", "template",
+        // Obsolete and deprecated elements
+        "acronym", "applet", "basefont", "big", "blink", "center", "dir", "frame", "frameset",
+        "isindex", "listing", "noembed", "plaintext", "spacer", "strike", "tt", "xmp"
     };
 
     //************* INLINES ****************


### PR DESCRIPTION
Actually the current change does not seem to fix this problem but I'm sort of out of ideas. I get messages like `Error: <aside> is not recognized!` for various tags like `<figure>`, `<figcaption>` and many more.                      
                                                                                     
I initially thought that modifying `HTML_TAGS`should do the trick but could not observe any change. I was searching the repo for strings like `not recognized` to figure out where the warning comes from but couldn't find any. 
                                                                                     
Any guidance appreciated. I hope we all agree that even if it's markdown people should generally be allowed to use all HTML tags.                                    