### PR TITLE
A few fixes accumulated from my plugin releases.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -12,6 +12,7 @@ Currently _pegdown_ supports the following extensions over standard Markdown:
 * QUOTES: Beautifies single quotes, double quotes and double angle quotes (&laquo; and &raquo;)
 * SMARTYPANTS: Convenience extension enabling both, SMARTS and QUOTES, at once.
 * ABBREVIATIONS: Abbreviations in the way of [PHP Markdown Extra](http://michelf.com/projects/php-markdown/extra/#abbr).
+* ANCHORLINKS: generate anchor links for headers by taking the first range of alphanumerics and spaces.
 * HARDWRAPS: Alternative handling of newlines, see [Github-flavoured-Markdown]
 * AUTOLINKS: Plain (undelimited) autolinks the way [Github-flavoured-Markdown] implements them.
 * TABLES: Tables similar to [MultiMarkdown](http://fletcherpenney.net/multimarkdown/) (which is in turn like the [PHP Markdown Extra](http://michelf.com/projects/php-markdown/extra/#table) tables, but with colspan support).
@@ -27,6 +28,8 @@ Currently _pegdown_ supports the following extensions over standard Markdown:
 * TASKLISTITEMS: parses bullet lists of the form `* [ ]` and `* [x]` to create GitHub like task list items:
     * [ ] open task item
     * [x] closed or completed task item.
+    * [X] also closed or completed task item.
+* EXTANCHORLINKS uses all text of the header for ANCHORLINKS, spaces and non-alphanumerics replaced by `-`, multiple dashes trimmed to one.
                         
 Note: _pegdown_ differs from the original Markdown in that it ignores in-word emphasis as in
 

--- a/src/main/java/org/pegdown/Extensions.java
+++ b/src/main/java/org/pegdown/Extensions.java
@@ -147,10 +147,15 @@ public interface Extensions {
     static final int TASKLISTITEMS = 0x00200000;
 
     /**
+     * GitHub style task list items: - [ ] and - [x]
+     */
+    static final int EXTANCHORLINKS = 0x00400000;
+
+    /**
      * All Optionals other than Suppress and FORCELISTITEMPARA which is a backwards compatibility extension
      *
      */
 
-    static final int ALL_OPTIONALS = (ATXHEADERSPACE  | RELAXEDHRULES | TASKLISTITEMS);
+    static final int ALL_OPTIONALS = (ATXHEADERSPACE  | RELAXEDHRULES | TASKLISTITEMS | EXTANCHORLINKS);
     static final int ALL_WITH_OPTIONALS = ALL | (ATXHEADERSPACE  | RELAXEDHRULES | TASKLISTITEMS);
 }

--- a/src/main/java/org/pegdown/Parser.java
+++ b/src/main/java/org/pegdown/Parser.java
@@ -343,7 +343,7 @@ public class Parser extends BaseParser<Object> implements Extensions {
     public void collectChildrensText(SuperNode node, AnchorNodeInfo nodeInfo) {
         for (Node child : node.getChildren()) {
             // accumulate all the text
-            if (child instanceof TextNode || child instanceof SpecialTextNode) {
+            if (child.getClass() == TextNode.class || child.getClass() == SpecialTextNode.class) {
                 nodeInfo.text.append(((TextNode) child).getText());
                 if (nodeInfo.startIndex == 0) {
                     nodeInfo.startIndex = child.getStartIndex();

--- a/src/main/java/org/pegdown/ToHtmlSerializer.java
+++ b/src/main/java/org/pegdown/ToHtmlSerializer.java
@@ -353,7 +353,7 @@ public class ToHtmlSerializer implements Visitor {
         serializer.serialize(node, printer);
     }
 
-    private VerbatimSerializer lookupSerializer(final String type) {
+    protected VerbatimSerializer lookupSerializer(final String type) {
         if (type != null && verbatimSerializers.containsKey(type)) {
             return verbatimSerializers.get(type);
         } else {
@@ -465,7 +465,7 @@ public class ToHtmlSerializer implements Visitor {
         printer.print('>').print(rendering.text).print("</a>");
     }
 
-    private void printAttribute(String name, String value) {
+    protected void printAttribute(String name, String value) {
         printer.print(' ').print(name).print('=').print('"').print(value).print('"');
     }
 

--- a/src/main/java/org/pegdown/ast/AnchorLinkNode.java
+++ b/src/main/java/org/pegdown/ast/AnchorLinkNode.java
@@ -27,6 +27,11 @@ public class AnchorLinkNode extends TextNode {
         this.name = generateName(text);
     }
 
+    public AnchorLinkNode(String textForName, String text) {
+        super(text);
+        this.name = generateName(textForName);
+    }
+
     @Override
     public void accept(Visitor visitor) {
         visitor.visit(this);

--- a/src/test/resources/CompoundLists/loose-shallow-forcepara.html
+++ b/src/test/resources/CompoundLists/loose-shallow-forcepara.html
@@ -26,4 +26,15 @@ Item 5 code block 1.2
     <li>
         <p>Loose Item 6</p>
     </li>
+    <li>
+        <p>Loose Item 7 after many blank lines</p>
+    </li>
 </ol>
+<ul>
+    <li>
+        <p>now the same for bullet lists</p>
+    </li>
+    <li>
+        <p>should be the same list</p>
+    </li>
+</ul>

--- a/src/test/resources/CompoundLists/loose-shallow.html
+++ b/src/test/resources/CompoundLists/loose-shallow.html
@@ -26,4 +26,16 @@ Item 5 code block 1.2
     <li>
         <p>Loose Item 6</p>
     </li>
+    <li>
+        <p>Loose Item 7 after many blank lines</p>
+    </li>
 </ol>
+<ul>
+    <li>
+        <p>now the same for bullet lists</p>
+    </li>
+    <li>
+        <p>should be the same list</p>
+    </li>
+</ul>
+

--- a/src/test/resources/CompoundLists/loose-shallow.md
+++ b/src/test/resources/CompoundLists/loose-shallow.md
@@ -38,3 +38,12 @@ Item 5 paragraph 2 lazy continuation
             Item 5 code block 2.2
 
 1. Loose Item 6
+
+
+1. Loose Item 7 after many blank lines
+
+- now the same for bullet lists
+
+
+
+- should be the same list

--- a/src/test/resources/OptionalExtensions/extanchors-ext.ast
+++ b/src/test/resources/OptionalExtensions/extanchors-ext.ast
@@ -1,0 +1,45 @@
+RootNode [0-132]
+  HeaderNode [0-39]
+    AnchorLinkNode [2-36] ''
+    TextNode [2-9] 'header '
+    SpecialTextNode [9-10] '&'
+    TextNode [10-16] ' some '
+    StrongEmphSuperNode [16-28]
+      TextNode [17-27] 'formatting'
+    TextNode [28-29] ' '
+    StrikeNode [29-38]
+      TextNode [31-36] 'chars'
+  HeaderNode [40-61]
+    AnchorLinkNode [42-60] ''
+    TextNode [42-48] 'header'
+    SpecialTextNode [48-49] '-'
+    TextNode [49-53] 'with'
+    SpecialTextNode [53-54] '-'
+    TextNode [54-60] 'dashes'
+  HeaderNode [62-81]
+    AnchorLinkNode [64-80] ''
+    TextNode [64-73] 'header/no'
+    SpecialTextNode [73-74] '-'
+    TextNode [74-80] 'header'
+  HeaderNode [82-132]
+    AnchorLinkNode [84-131] ''
+    TextNode [84-91] 'header '
+    StrongEmphSuperNode [91-131]
+      StrongEmphSuperNode [92-131]
+        SpecialTextNode [93-94] '`'
+        SpecialTextNode [94-95] '&'
+        SpecialTextNode [95-96] '['
+        SpecialTextNode [96-97] ']'
+        SpecialTextNode [97-98] '<'
+        SpecialTextNode [98-99] '>'
+        SpecialTextNode [99-100] '!'
+        SpecialTextNode [100-101] '#'
+        SpecialTextNode [101-102] '.'
+        SpecialTextNode [102-103] '-'
+        SpecialTextNode [103-104] '('
+        SpecialTextNode [104-105] ')'
+        SpecialTextNode [105-106] '{'
+        SpecialTextNode [106-107] '}'
+        SpecialTextNode [107-108] ':'
+        SpecialTextNode [108-109] '|'
+        TextNode [109-131] ' special chars ignored'

--- a/src/test/resources/OptionalExtensions/extanchors-ext.html
+++ b/src/test/resources/OptionalExtensions/extanchors-ext.html
@@ -1,0 +1,3 @@
+<h1><a href="#header-some-formatting-chars" name= "header-some-formatting-chars"></a>header &amp; some <em>formatting</em> <del>chars</del></h1>
+<h1><a href="#header-with-dashes" name= "header-with-dashes"></a>header-with-dashes</h1> <h1><a href="#header-no-header" name= "header-no-header"></a>header/no-header</h1>
+<h1><a href="#header-special-chars-ignored" name= "header-special-chars-ignored"></a>header *_`&amp;[]&lt;&gt;!#.-(){}:| special chars ignored</h1>

--- a/src/test/resources/OptionalExtensions/extanchors-no-ext.ast
+++ b/src/test/resources/OptionalExtensions/extanchors-no-ext.ast
@@ -1,0 +1,41 @@
+RootNode [0-132]
+  HeaderNode [0-39]
+    TextNode [2-9] 'header '
+    SpecialTextNode [9-10] '&'
+    TextNode [10-16] ' some '
+    StrongEmphSuperNode [16-28]
+      TextNode [17-27] 'formatting'
+    TextNode [28-29] ' '
+    StrikeNode [29-38]
+      TextNode [31-36] 'chars'
+  HeaderNode [40-61]
+    TextNode [42-48] 'header'
+    SpecialTextNode [48-49] '-'
+    TextNode [49-53] 'with'
+    SpecialTextNode [53-54] '-'
+    TextNode [54-60] 'dashes'
+  HeaderNode [62-81]
+    TextNode [64-73] 'header/no'
+    SpecialTextNode [73-74] '-'
+    TextNode [74-80] 'header'
+  HeaderNode [82-132]
+    TextNode [84-91] 'header '
+    StrongEmphSuperNode [91-131]
+      StrongEmphSuperNode [92-131]
+        SpecialTextNode [93-94] '`'
+        SpecialTextNode [94-95] '&'
+        SpecialTextNode [95-96] '['
+        SpecialTextNode [96-97] ']'
+        SpecialTextNode [97-98] '<'
+        SpecialTextNode [98-99] '>'
+        SpecialTextNode [99-100] '!'
+        SpecialTextNode [100-101] '#'
+        SpecialTextNode [101-102] '.'
+        SpecialTextNode [102-103] '-'
+        SpecialTextNode [103-104] '('
+        SpecialTextNode [104-105] ')'
+        SpecialTextNode [105-106] '{'
+        SpecialTextNode [106-107] '}'
+        SpecialTextNode [107-108] ':'
+        SpecialTextNode [108-109] '|'
+        TextNode [109-131] ' special chars ignored'

--- a/src/test/resources/OptionalExtensions/extanchors-no-ext.html
+++ b/src/test/resources/OptionalExtensions/extanchors-no-ext.html
@@ -1,0 +1,4 @@
+<h1>header &amp; some <em>formatting</em> <del>chars</del></h1>
+<h1>header-with-dashes</h1>
+<h1>header/no-header</h1>
+<h1>header *_`&amp;[]&lt;&gt;!#.-(){}:| special chars ignored</h1>

--- a/src/test/resources/OptionalExtensions/extanchors.md
+++ b/src/test/resources/OptionalExtensions/extanchors.md
@@ -1,0 +1,8 @@
+# header & some *formatting* ~~chars~~
+
+# header-with-dashes
+
+# header/no-header
+
+# header *_`&[]<>!#.-(){}:| special chars ignored
+

--- a/src/test/resources/OptionalExtensions/task-lists-ext.ast
+++ b/src/test/resources/OptionalExtensions/task-lists-ext.ast
@@ -1,39 +1,44 @@
-RootNode [0-190]
-  BulletListNode [1-190]
-    ListItemNode [3-18]
-      RootNode [3-18]
-        SuperNode [3-18]
-          TextNode [3-17] 'open task item'
-    ListItemNode [20-37]
-      RootNode [20-37]
-        SuperNode [20-37]
-          TextNode [20-36] 'closed task item'
-    ListItemNode [40-60]
-      RootNode [40-60]
-        ParaNode [40-60]
-          SuperNode [40-60]
-            TextNode [40-60] 'loose open task item'
-    ListItemNode [64-86]
-      RootNode [64-86]
-        ParaNode [64-86]
-          SuperNode [64-86]
-            TextNode [64-86] 'loose closed task item'
-    TaskListNode [94-108]
-      RootNode [94-108]
-        ParaNode [94-108]
-          SuperNode [94-108]
-            TextNode [94-108] 'open task item'
-    TaskListNode [115-132]
-      RootNode [115-132]
-        SuperNode [115-132]
-          TextNode [115-131] 'closed task item'
-    TaskListNode [139-159]
-      RootNode [139-159]
-        ParaNode [139-159]
-          SuperNode [139-159]
-            TextNode [139-159] 'loose open task item'
-    TaskListNode [167-189]
-      RootNode [167-189]
-        ParaNode [167-189]
-          SuperNode [167-189]
-            TextNode [167-189] 'loose closed task item'
+RootNode [0-229]
+  BulletListNode [1-229]
+    TaskListNode [7-22]
+      RootNode [7-22]
+        ParaNode [7-22]
+          SuperNode [7-22]
+            TextNode [7-21] 'open task item'
+    TaskListNode [29-68]
+      RootNode [29-68]
+        ParaNode [29-68]
+          SuperNode [29-68]
+            TextNode [29-68] 'loose second, will make first one loose'
+    ListItemNode [72-83]
+      RootNode [72-83]
+        ParaNode [72-83]
+          SuperNode [72-83]
+            TextNode [72-83] 'bullet item'
+    ListItemNode [86-100]
+      RootNode [86-100]
+        SuperNode [86-100]
+          TextNode [86-99] 'bullet item 2'
+    ListItemNode [103-122]
+      RootNode [103-122]
+        ParaNode [103-122]
+          SuperNode [103-122]
+            TextNode [103-122] 'loose bullet item 3'
+    TaskListNode [129-144]
+      RootNode [129-144]
+        SuperNode [129-144]
+          TextNode [129-143] 'open task item'
+    TaskListNode [150-167]
+      RootNode [150-167]
+        SuperNode [150-167]
+          TextNode [150-166] 'closed task item'
+    TaskListNode [176-196]
+      RootNode [176-196]
+        ParaNode [176-196]
+          SuperNode [176-196]
+            TextNode [176-196] 'loose open task item'
+    TaskListNode [206-228]
+      RootNode [206-228]
+        ParaNode [206-228]
+          SuperNode [206-228]
+            TextNode [206-228] 'loose closed task item'

--- a/src/test/resources/OptionalExtensions/task-lists-ext.html
+++ b/src/test/resources/OptionalExtensions/task-lists-ext.html
@@ -1,15 +1,25 @@
 <ul>
-  <li>open task item</li>
-  <li>closed task item</li>
-  <li>
-  <p>loose open task item</p></li>
-  <li>
-  <p>loose closed task item</p></li>
-  <li class="task-list-item">
-  <p><input type="checkbox" class="task-list-item-checkbox" disabled="disabled"></input>open task item</p></li>
-  <li class="task-list-item"><input type="checkbox" class="task-list-item-checkbox" checked="checked" disabled="disabled"></input>closed task item</li>
-  <li class="task-list-item">
-  <p><input type="checkbox" class="task-list-item-checkbox" disabled="disabled"></input>loose open task item</p></li>
-  <li class="task-list-item">
-  <p><input type="checkbox" class="task-list-item-checkbox" checked="checked" disabled="disabled"></input>loose closed task item</p></li>
+    <li class="task-list-item">
+        <p><input type="checkbox" class="task-list-item-checkbox" disabled="disabled">open task item</p>
+    </li>
+    <li class="task-list-item">
+        <p><input type="checkbox" class="task-list-item-checkbox" disabled="disabled">loose second, will make first one loose</p>
+    </li>
+    <li>
+        <p>bullet item</p>
+    </li>
+    <li>bullet item 2</li>
+    <li>
+        <p>loose bullet item 3</p>
+    </li>
+    <li class="task-list-item"><input type="checkbox" class="task-list-item-checkbox" disabled="disabled">open task item
+    </li>
+    <li class="task-list-item"><input type="checkbox" class="task-list-item-checkbox" checked="checked" disabled="disabled">closed task item
+    </li>
+    <li class="task-list-item">
+        <p><input type="checkbox" class="task-list-item-checkbox" disabled="disabled">loose open task item</p>
+    </li>
+    <li class="task-list-item">
+        <p><input type="checkbox" class="task-list-item-checkbox" checked="checked" disabled="disabled">loose closed task item</p>
+    </li>
 </ul>

--- a/src/test/resources/OptionalExtensions/task-lists-no-ext.ast
+++ b/src/test/resources/OptionalExtensions/task-lists-no-ext.ast
@@ -1,51 +1,62 @@
-RootNode [0-190]
-  BulletListNode [1-190]
-    ListItemNode [3-18]
-      RootNode [3-18]
-        SuperNode [3-18]
-          TextNode [3-17] 'open task item'
-    ListItemNode [20-37]
-      RootNode [20-37]
-        SuperNode [20-37]
-          TextNode [20-36] 'closed task item'
-    ListItemNode [40-60]
-      RootNode [40-60]
-        ParaNode [40-60]
-          SuperNode [40-60]
-            TextNode [40-60] 'loose open task item'
-    ListItemNode [64-86]
-      RootNode [64-86]
-        ParaNode [64-86]
-          SuperNode [64-86]
-            TextNode [64-86] 'loose closed task item'
-    ListItemNode [90-108]
-      RootNode [90-108]
-        ParaNode [90-108]
-          SuperNode [90-108]
-            RefLinkNode [90-93]
-              SuperNode [90-90]
-                TextNode [91-92] ' '
-            TextNode [93-108] ' open task item'
-    ListItemNode [111-132]
-      RootNode [111-132]
-        SuperNode [111-132]
-          RefLinkNode [111-114]
-            SuperNode [111-111]
-              TextNode [112-113] 'x'
-          TextNode [114-131] ' closed task item'
-    ListItemNode [135-159]
-      RootNode [135-159]
-        ParaNode [135-159]
-          SuperNode [135-159]
-            RefLinkNode [135-138]
-              SuperNode [135-135]
-                TextNode [136-137] ' '
-            TextNode [138-159] ' loose open task item'
-    ListItemNode [163-189]
-      RootNode [163-189]
-        ParaNode [163-189]
-          SuperNode [163-189]
-            RefLinkNode [163-166]
-              SuperNode [163-163]
-                TextNode [164-165] 'x'
-            TextNode [166-189] ' loose closed task item'
+RootNode [0-229]
+  BulletListNode [1-229]
+    ListItemNode [3-22]
+      RootNode [3-22]
+        ParaNode [3-22]
+          SuperNode [3-22]
+            RefLinkNode [3-6]
+              SuperNode [3-3]
+                TextNode [4-5] ' '
+            TextNode [6-21] ' open task item'
+    ListItemNode [25-68]
+      RootNode [25-68]
+        ParaNode [25-68]
+          SuperNode [25-68]
+            RefLinkNode [25-28]
+              SuperNode [25-25]
+                TextNode [26-27] ' '
+            TextNode [28-68] ' loose second, will make first one loose'
+    ListItemNode [72-83]
+      RootNode [72-83]
+        ParaNode [72-83]
+          SuperNode [72-83]
+            TextNode [72-83] 'bullet item'
+    ListItemNode [86-100]
+      RootNode [86-100]
+        SuperNode [86-100]
+          TextNode [86-99] 'bullet item 2'
+    ListItemNode [103-122]
+      RootNode [103-122]
+        ParaNode [103-122]
+          SuperNode [103-122]
+            TextNode [103-122] 'loose bullet item 3'
+    ListItemNode [125-144]
+      RootNode [125-144]
+        SuperNode [125-144]
+          RefLinkNode [125-128]
+            SuperNode [125-125]
+              TextNode [126-127] ' '
+          TextNode [128-143] ' open task item'
+    ListItemNode [146-167]
+      RootNode [146-167]
+        SuperNode [146-167]
+          RefLinkNode [146-149]
+            SuperNode [146-146]
+              TextNode [147-148] 'x'
+          TextNode [149-166] ' closed task item'
+    ListItemNode [172-196]
+      RootNode [172-196]
+        ParaNode [172-196]
+          SuperNode [172-196]
+            RefLinkNode [172-175]
+              SuperNode [172-172]
+                TextNode [173-174] ' '
+            TextNode [175-196] ' loose open task item'
+    ListItemNode [202-228]
+      RootNode [202-228]
+        ParaNode [202-228]
+          SuperNode [202-228]
+            RefLinkNode [202-205]
+              SuperNode [202-202]
+                TextNode [203-204] 'X'
+            TextNode [205-228] ' loose closed task item'

--- a/src/test/resources/OptionalExtensions/task-lists-no-ext.html
+++ b/src/test/resources/OptionalExtensions/task-lists-no-ext.html
@@ -1,15 +1,24 @@
 <ul>
-  <li>open task item</li>
-  <li>closed task item</li>
-  <li>
-  <p>loose open task item</p></li>
-  <li>
-  <p>loose closed task item</p></li>
-  <li>
-  <p>[ ] open task item</p></li>
-  <li>[x] closed task item</li>
-  <li>
-  <p>[ ] loose open task item</p></li>
-  <li>
-  <p>[x] loose closed task item</p></li>
+    <li>
+        <p>[ ] open task item</p>
+    </li>
+    <li>
+        <p>[ ] loose second, will make first one loose</p>
+    </li>
+    <li>
+        <p>bullet item</p>
+    </li>
+    <li>bullet item 2</li>
+    <li>
+        <p>loose bullet item 3</p>
+    </li>
+    <li>[ ] open task item</li>
+    <li>[x] closed task item</li>
+    <li>
+        <p>[ ] loose open task item</p>
+    </li>
+    <li>
+        <p>[X] loose closed task item</p>
+    </li>
 </ul>
+

--- a/src/test/resources/OptionalExtensions/task-lists.md
+++ b/src/test/resources/OptionalExtensions/task-lists.md
@@ -1,14 +1,19 @@
 
-* open task item
-* closed task item
+* [ ] open task item
 
-* loose open task item
+* [ ] loose second, will make first one loose
 
-* loose closed task item
+* bullet item
+* bullet item 2
 
+* loose bullet item 3
 * [ ] open task item
 * [x] closed task item
 
+
+
 * [ ] loose open task item
 
-* [x] loose closed task item
+
+
+* [X] loose closed task item

--- a/src/test/resources/pegdown/AstText.ast
+++ b/src/test/resources/pegdown/AstText.ast
@@ -23,9 +23,10 @@ RootNode [0-942]
       TextNode [161-181] 'the functionality of'
   BulletListNode [183-299]
     ListItemNode [185-225]
-      ParaNode [185-204]
-        SuperNode [185-204]
-          TextNode [185-203] 'AST index creation'
+      RootNode [185-204]
+        ParaNode [185-204]
+          SuperNode [185-204]
+            TextNode [185-203] 'AST index creation'
       RootNode [208-225]
         BulletListNode [208-225]
           ListItemNode [210-225]

--- a/src/test/scala/org/pegdown/OptionalExtensionsSpec.scala
+++ b/src/test/scala/org/pegdown/OptionalExtensionsSpec.scala
@@ -35,24 +35,51 @@ class OptionalExtensionsSpec extends AbstractPegDownSpec {
       "hrules-not-relaxed" in {
         implicit val processor = new PegDownProcessor(ALL)
         testAlt("OptionalExtensions/hrules", "-not-relaxed")
+      }
+      "hrules-not-relaxed AST" in {
+        implicit val processor = new PegDownProcessor(ALL)
         testASTAlt("OptionalExtensions/hrules", "-not-relaxed")
       }
       "hrules-relaxed" in {
         implicit val processor = new PegDownProcessor(ALL | RELAXEDHRULES)
         testAlt("OptionalExtensions/hrules", "-relaxed")
+      }
+      "hrules-relaxed AST" in {
+        implicit val processor = new PegDownProcessor(ALL | RELAXEDHRULES)
         testASTAlt("OptionalExtensions/hrules", "-relaxed")
       }
       "task-lists-no-ext" in {
         implicit val processor = new PegDownProcessor(ALL)
         testAlt("OptionalExtensions/task-lists", "-no-ext")
+      }
+      "task-lists-no-ext AST" in {
+        implicit val processor = new PegDownProcessor(ALL)
         testASTAlt("OptionalExtensions/task-lists", "-no-ext")
       }
       "task-lists-ext" in {
         implicit val processor = new PegDownProcessor(ALL | TASKLISTITEMS)
         testAlt("OptionalExtensions/task-lists", "-ext")
+      }
+      "task-lists-ext AST" in {
+        implicit val processor = new PegDownProcessor(ALL | TASKLISTITEMS)
         testASTAlt("OptionalExtensions/task-lists", "-ext")
+      }
+      "extanchors-no-ext" in {
+        implicit val processor = new PegDownProcessor(ALL)
+        testAlt("OptionalExtensions/extanchors", "-no-ext")
+      }
+      "extanchors-no-ext AST" in {
+        implicit val processor = new PegDownProcessor(ALL)
+        testASTAlt("OptionalExtensions/extanchors", "-no-ext")
+      }
+      "extanchors-ext" in {
+        implicit val processor = new PegDownProcessor(ALL | EXTANCHORLINKS)
+        testAlt("OptionalExtensions/extanchors", "-ext")
+      }
+      "extanchors-ext AST" in {
+        implicit val processor = new PegDownProcessor(ALL | EXTANCHORLINKS)
+        testASTAlt("OptionalExtensions/extanchors", "-ext")
       }
     }
   }
-
 }


### PR DESCRIPTION
…the header as part of the anchor name generator text, text accumulated, special chars ignored. Fix #194

fix #190, two or more blank lines between list items would break the list into separate lists
fix #191, completed task list items could have capital X not just lowercase. [X] and [x] are equivalent.
fix #192, paragraph wrapping for list items would produce an AST different from how blank lines before list items. Now identical.
fix #193 change private to protected methods in ToHtmlSerializer so that it can be extended without duplicating code